### PR TITLE
Add JUnit Pioneer; reduce digits shown in approximateCount detail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     <!-- Versions for test dependencies -->
     <curator.version>2.13.0</curator.version>
     <jackson.version>2.10.5</jackson.version>
+    <junit-pioneer.version>1.1.0</junit-pioneer.version>
     <kiwi-test.version>0.12.0</kiwi-test.version>
 
     <!-- Versions for plugins -->
@@ -271,13 +272,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.kiwiproject</groupId>
-      <artifactId>kiwi-test</artifactId>
-      <version>${kiwi-test.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
       <version>${jackson.version}</version>
@@ -292,6 +286,39 @@
           <artifactId>jakarta.xml.bind-api</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit-pioneer</groupId>
+      <artifactId>junit-pioneer</artifactId>
+      <version>${junit-pioneer.version}</version>
+      <scope>test</scope>
+      <!-- Because Pioneer is not on Jupiter 5.7.0 yet -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-params</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.junit.platform</groupId>
+          <artifactId>junit-platform-commons</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.junit.platform</groupId>
+          <artifactId>junit-platform-launcher</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kiwiproject</groupId>
+      <artifactId>kiwi-test</artifactId>
+      <version>${kiwi-test.version}</version>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/ServerErrorHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/ServerErrorHealthCheck.java
@@ -77,7 +77,7 @@ public class ServerErrorHealthCheck extends HealthCheck {
 
         return setupResultBuilder(estimatedErrorCount)
                 .withDetail("rate", meter.getFifteenMinuteRate())
-                .withDetail("approximateCount", estimatedErrorCount)
+                .withDetail("approximateCount", toDoubleWithOneDecimalPlace(estimatedErrorCount))
                 .withDetail("warningThreshold", warningThreshold)
                 .withDetail("criticalThreshold", criticalThreshold)
                 .withDetail("meter", METER_NAME)
@@ -95,5 +95,12 @@ public class ServerErrorHealthCheck extends HealthCheck {
 
         return newResultBuilder(true)
                 .withMessage("No %s", MSG_SUFFIX);
+    }
+
+    // I am 100% sure this isn't even remotely close to the most efficient way to do this.
+    // Feel free to improve it and submit a PR.
+    @VisibleForTesting
+    static double toDoubleWithOneDecimalPlace(double value) {
+        return Double.parseDouble(String.format("%.1f", value));
     }
 }

--- a/src/test/java/org/kiwiproject/dropwizard/util/health/ServerErrorHealthCheckTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/health/ServerErrorHealthCheckTest.java
@@ -5,6 +5,7 @@ import static org.kiwiproject.dropwizard.util.health.ServerErrorHealthCheck.DEFA
 import static org.kiwiproject.dropwizard.util.health.ServerErrorHealthCheck.FIFTEEN_MINUTES_IN_SECONDS;
 import static org.kiwiproject.dropwizard.util.health.ServerErrorHealthCheck.METER_NAME;
 import static org.kiwiproject.dropwizard.util.health.ServerErrorHealthCheck.METRIC_FILTER;
+import static org.kiwiproject.dropwizard.util.health.ServerErrorHealthCheck.toDoubleWithOneDecimalPlace;
 import static org.kiwiproject.test.assertj.dropwizard.metrics.HealthCheckResultAssertions.assertThatHealthCheck;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -16,7 +17,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junitpioneer.jupiter.params.DoubleRangeSource;
 import org.kiwiproject.metrics.health.HealthStatus;
 
 import java.util.TreeMap;
@@ -67,7 +68,7 @@ class ServerErrorHealthCheckTest {
         }
 
         @ParameterizedTest
-        @ValueSource(doubles = {0.0, 0.5, 0.999999})
+        @DoubleRangeSource(from = 0.0, to = 1.0, step = 0.1)
         void whenRequiredMeterIsReturnedAndRateIsLessThanThreshold(double count) {
             var meter = mock(Meter.class);
             when(meter.getFifteenMinuteRate()).thenReturn(count / FIFTEEN_MINUTES_IN_SECONDS);
@@ -81,7 +82,7 @@ class ServerErrorHealthCheckTest {
                     .isHealthy()
                     .hasMessage("No 5xx error responses in the last 15 minutes")
                     .hasDetail("rate", count / FIFTEEN_MINUTES_IN_SECONDS)
-                    .hasDetail("approximateCount", count)
+                    .hasDetail("approximateCount", toDoubleWithOneDecimalPlace(count))
                     .hasDetail("warningThreshold", DEFAULT_WARNING_THRESHOLD)
                     .hasDetail("criticalThreshold", DEFAULT_CRITICAL_THRESHOLD)
                     .hasDetail("meter", METER_NAME);
@@ -92,7 +93,7 @@ class ServerErrorHealthCheckTest {
     class IsUnhealthy {
 
         @ParameterizedTest
-        @ValueSource(doubles = {1.0, 5.0, 9.999999})
+        @DoubleRangeSource(from = 1.0, to = 10.0, step = 0.1)
         void withWarningSeverity_WhenRateIsEqualToOrGreaterThanWarningThreshold(double count) {
             var meter = mock(Meter.class);
             when(meter.getFifteenMinuteRate()).thenReturn(count / FIFTEEN_MINUTES_IN_SECONDS);
@@ -107,14 +108,14 @@ class ServerErrorHealthCheckTest {
                     .hasDetail("severity", HealthStatus.WARN.name())
                     .hasMessage("Some 5xx error responses in the last 15 minutes")
                     .hasDetail("rate", count / FIFTEEN_MINUTES_IN_SECONDS)
-                    .hasDetail("approximateCount", count)
+                    .hasDetail("approximateCount", toDoubleWithOneDecimalPlace(count))
                     .hasDetail("warningThreshold", DEFAULT_WARNING_THRESHOLD)
                     .hasDetail("criticalThreshold", DEFAULT_CRITICAL_THRESHOLD)
                     .hasDetail("meter", METER_NAME);
         }
 
         @ParameterizedTest
-        @ValueSource(doubles = {10.0, 100.0})
+        @DoubleRangeSource(from = 10.0, to = 100.0)
         void withCriticalSeverity_WhenRateIsEqualToOrGreaterThanCriticalThreshold(double count) {
             var meter = mock(Meter.class);
             when(meter.getFifteenMinuteRate()).thenReturn(count / FIFTEEN_MINUTES_IN_SECONDS);
@@ -129,7 +130,7 @@ class ServerErrorHealthCheckTest {
                     .hasDetail("severity", HealthStatus.CRITICAL.name())
                     .hasMessage("Critical level of 5xx error responses in the last 15 minutes")
                     .hasDetail("rate", count / FIFTEEN_MINUTES_IN_SECONDS)
-                    .hasDetail("approximateCount", count)
+                    .hasDetail("approximateCount", toDoubleWithOneDecimalPlace(count))
                     .hasDetail("warningThreshold", DEFAULT_WARNING_THRESHOLD)
                     .hasDetail("criticalThreshold", DEFAULT_CRITICAL_THRESHOLD)
                     .hasDetail("meter", METER_NAME);


### PR DESCRIPTION
* Update ServerErrorHealthCheck to show only one decimal place in the
  approximateCount result detail
* Add JUnit Pioneer 1.1.0 with exclusions since they are only on
  Jupiter 5.5.2 instead of 5.7.0
* Change ServerErrorHealthCheckTest to use Pioneer's @DoubleRangeSource
* Move kiwi-test dependency to its correct order below the "j" deps

Closes #54
Closes #57