### PR TITLE
Fix Maven convergence error with junit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,10 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 


### PR DESCRIPTION
For whatever reason, junit 3.8 is brought in transitively jline which is
brought in from ZooKeeper.