### PR TITLE
Fix warning when creating ConfigResource

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/admin/AdminConfigurator.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/admin/AdminConfigurator.java
@@ -191,7 +191,7 @@ public class AdminConfigurator {
 
     private void addConfigResource() {
         if (shouldIncludeConfigResource) {
-            environment.jersey().register(new ConfigResource<>(config, hiddenFieldRegex));
+            environment.jersey().register(new ConfigResource(config, hiddenFieldRegex));
         }
     }
 }

--- a/src/main/java/org/kiwiproject/dropwizard/util/resource/ConfigResource.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/resource/ConfigResource.java
@@ -22,13 +22,13 @@ import java.util.List;
  */
 @Slf4j
 @Path("app/config")
-public class ConfigResource<T extends Configuration> {
+public class ConfigResource {
 
     // Intentionally creating a separate JsonHelper to allow customizations
     private final JsonHelper jsonHelper;
-    private final T config;
+    private final Configuration config;
 
-    public ConfigResource(T config, List<String> hiddenRegex) {
+    public ConfigResource(Configuration config, List<String> hiddenRegex) {
         this.config = config;
         this.jsonHelper = JsonHelper.newDropwizardJsonHelper();
 

--- a/src/test/java/org/kiwiproject/dropwizard/util/resource/ConfigResourceTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/resource/ConfigResourceTest.java
@@ -36,7 +36,7 @@ class ConfigResourceTest {
 
         @Override
         public void run(TestConfig config, Environment environment) {
-            environment.jersey().register(new ConfigResource<>(config, List.of(".*Password")));
+            environment.jersey().register(new ConfigResource(config, List.of(".*Password")));
         }
     }
 


### PR DESCRIPTION
There is not a need for ConfigResource to be generic since all configurations
will extend Dropwizard's Configuration class

Closes #71