### PR TITLE
Introduce ExecutionStrategy as pluggable strategy to SystemExecutioner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,11 @@
         <sonar.projectKey>kiwiproject_dropwizard-service-utilities</sonar.projectKey>
         <sonar.organization>kiwiproject</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.coverage.exclusions>org/kiwiproject/dropwizard/util/startup/SystemExecutioner.java
-        </sonar.coverage.exclusions>
+        <!-- TODO Remove this exclusion -->
+        <!--
+                <sonar.coverage.exclusions>org/kiwiproject/dropwizard/util/startup/SystemExecutioner.java
+                </sonar.coverage.exclusions>
+        -->
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -63,11 +63,6 @@
         <sonar.projectKey>kiwiproject_dropwizard-service-utilities</sonar.projectKey>
         <sonar.organization>kiwiproject</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <!-- TODO Remove this exclusion -->
-        <!--
-                <sonar.coverage.exclusions>org/kiwiproject/dropwizard/util/startup/SystemExecutioner.java
-                </sonar.coverage.exclusions>
-        -->
     </properties>
 
     <dependencies>

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategies.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategies.java
@@ -1,0 +1,124 @@
+package org.kiwiproject.dropwizard.util.startup;
+
+import lombok.Getter;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Factory for {@link ExecutionStrategy} instances.
+ */
+@UtilityClass
+public class ExecutionStrategies {
+
+    /**
+     * Returns a strategy that does nothing (is a "no-op").
+     *
+     * @return a no-op ExecutionStrategy
+     */
+    public static ExecutionStrategy noOp() {
+        return new NoOpExecutionStrategy();
+    }
+
+    /**
+     * Returns a strategy that "flags" when the {@code exit()} method is called, but does not actually
+     * terminate the JVM.
+     *
+     * @return an exit-flagging ExecutionStrategy
+     */
+    public static ExecutionStrategy exitFlagging() {
+        return new ExitFlaggingExecutionStrategy();
+    }
+
+    /**
+     * Returns a strategy that uses the {@link System} class to exit/terminate the JVM.
+     *
+     * @return a strategy that uses {@link System#exit(int)} that sets the exit code to 1 (one)
+     */
+    public static ExecutionStrategy systemExit() {
+        return new SystemExitExecutionStrategy();
+    }
+
+    /**
+     * Returns a strategy that uses the {@link System} class to exit/terminate the JVM.
+     *
+     * @param exitCode the exit code that will be supplied to {@link System#exit(int)}
+     * @return a strategy that uses {@link System#exit(int)} that uses the given exit code
+     */
+    public static ExecutionStrategy systemExit(int exitCode) {
+        return new SystemExitExecutionStrategy(exitCode);
+    }
+
+    /**
+     * Implementation of {@link ExecutionStrategy} that uses {@link System#exit(int)}.
+     */
+    @Slf4j
+    public static class SystemExitExecutionStrategy implements ExecutionStrategy {
+
+        @Getter
+        private final int exitCode;
+
+        /**
+         * Construct an instance that will set the exit code to 1 (one).
+         */
+        public SystemExitExecutionStrategy() {
+            this(1);
+        }
+
+        /**
+         * Construct an instance that will use the given exit code.
+         *
+         * @param exitCode the exit code for {@link System#exit(int)}
+         */
+        public SystemExitExecutionStrategy(int exitCode) {
+            this.exitCode = exitCode;
+        }
+
+        /**
+         * Terminates the currently running JVM.
+         */
+        @Override
+        public void exit() {
+            LOG.warn("Terminating the VM!");
+            System.exit(exitCode);
+        }
+    }
+
+    /**
+     * Implementation of {@link ExecutionStrategy} that does nothing.
+     */
+    public static class NoOpExecutionStrategy implements ExecutionStrategy {
+
+        /**
+         * A no-op. Mainly useful in unit testing scenarios.
+         */
+        @Override
+        public void exit() {
+            // Intentionally empty
+        }
+    }
+
+    /**
+     * Implementation of {@link ExecutionStrategy} that "flags" a call to {@link #exit()} but does not actually
+     * exit the JVM.
+     */
+    public static class ExitFlaggingExecutionStrategy implements ExecutionStrategy {
+
+        private final AtomicBoolean didExit = new AtomicBoolean();
+
+        @Override
+        public void exit() {
+            didExit.set(true);
+        }
+
+        /**
+         * Was {@link #exit()} called?
+         *
+         * @return true if exit was called, otherwise false
+         */
+        public boolean didExit() {
+            return didExit.get();
+        }
+    }
+}

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategy.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategy.java
@@ -1,0 +1,12 @@
+package org.kiwiproject.dropwizard.util.startup;
+
+/**
+ * Defines a strategy used in {@link SystemExecutioner} to terminate the JVM.
+ */
+public interface ExecutionStrategy {
+
+    /**
+     * Performs the exit operation.
+     */
+    void exit();
+}

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/SystemExecutioner.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/SystemExecutioner.java
@@ -1,17 +1,66 @@
 package org.kiwiproject.dropwizard.util.startup;
 
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.kiwiproject.base.DefaultEnvironment;
+
+import java.util.concurrent.TimeUnit;
 
 /**
- * Wrapper around {@link System#exit(int)} to allow for unit testing scenarios in which we need to exit the JVM, for
- * example when the Jetty server cannot start due to failure to obtain a port, or some other non-recoverable startup
- * error.
+ * Wrapper around {@link System#exit(int)} for situations in which the JVM must be exited. This class is mainly
+ * intended for scenarios in which production code may call {@link System#exit(int)} in order to allow unit testing
+ * of the exit behavior, but without actually exiting the JVM. For example, a Jetty server that cannot start due to
+ * failure to obtain a port, or any other non-recoverable startup error that would otherwise result in a hung or
+ * unresponsive server, application, resource, etc. In situations like this, you can test that the
+ * {@link SystemExecutioner} would have exited when specific errors occur.
+ * <p>
+ * The no-args constructor uses the {@link ExecutionStrategies.SystemExitExecutionStrategy}, which uses
+ * {@link System#exit(int)} to terminate the JVM. You can supply your own {@link ExecutionStrategy} as well, for
+ * example {@link ExecutionStrategies.NoOpExecutionStrategy} is useful in unit tests (so it doesn't actually terminate
+ * the JVM).
  */
 @Slf4j
 public class SystemExecutioner {
 
+    /**
+     * The execution strategy to use when one of the {@code exit} methods is called.
+     */
+    @Getter
+    private final ExecutionStrategy executionStrategy;
+
+    /**
+     * Creates a new {@link SystemExecutioner} using the default {@link ExecutionStrategy}, which is
+     * {@link ExecutionStrategies.SystemExitExecutionStrategy}.
+     */
+    public SystemExecutioner() {
+        this(ExecutionStrategies.systemExit());
+    }
+
+    /**
+     * Creates a new {@link SystemExecutioner} using the given {@link ExecutionStrategy}.
+     *
+     * @param executionStrategy the strategy to use
+     */
+    public SystemExecutioner(ExecutionStrategy executionStrategy) {
+        this.executionStrategy = executionStrategy;
+    }
+
+    /**
+     * Exits immediately.
+     */
     public void exit() {
-        LOG.warn("Terminating the VM!");
-        System.exit(1);
+        executionStrategy.exit();
+    }
+
+    /**
+     * Waits the given amount of time, then exits.
+     *
+     * @param waitTime     the wait time amount
+     * @param waitTimeUnit the wait time unit
+     */
+    public void exit(long waitTime, TimeUnit waitTimeUnit) {
+        LOG.warn("Waiting {} {} before exiting", waitTime, waitTimeUnit);
+        new DefaultEnvironment().sleepQuietly(waitTime, waitTimeUnit);
+        exit();
     }
 }

--- a/src/test/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategiesTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategiesTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @DisplayName("ExecutionStrategies")
+@Slf4j
 class ExecutionStrategiesTest {
 
     @Test
@@ -86,7 +87,9 @@ class ExecutionStrategiesTest {
             var result = execTestApplication(exitCode, exitWaitDelayMillis);
 
             assertThat(result.pid).isPositive();
-            assertThat(result.exitValue).isEqualTo(exitCode);
+            assertThat(result.exitValue)
+                    .describedAs("Expecting non-null exit code (null means timeout waiting for process to exit)")
+                    .isEqualTo(exitCode);
         }
     }
 
@@ -115,9 +118,14 @@ class ExecutionStrategiesTest {
                 String.valueOf(exitCode),
                 String.valueOf(exitWaitDelayMillis));
 
+        LOG.debug("Executing TestApplication using {} with exitCode {} and exitWaitDelayMillis {}",
+                javaBin, exitCode, exitWaitDelayMillis);
         var process = new ProcessBuilder(command).start();
-        var exitValueOrNull = Processes.waitForExit(process, 1, TimeUnit.SECONDS).orElse(null);
-        return new ExecResult(process.pid(), exitValueOrNull);
+        var exitValueOrNull = Processes.waitForExit(process, 5, TimeUnit.SECONDS).orElse(null);
+        var execResult = new ExecResult(process.pid(), exitValueOrNull);
+        LOG.debug("Received result: {}", execResult);
+
+        return execResult;
     }
 
     @Value

--- a/src/test/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategiesTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategiesTest.java
@@ -1,0 +1,128 @@
+package org.kiwiproject.dropwizard.util.startup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.kiwiproject.test.assertj.KiwiAssertJ.assertIsExactType;
+
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.kiwiproject.base.process.Processes;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@DisplayName("ExecutionStrategies")
+class ExecutionStrategiesTest {
+
+    @Test
+    void shouldBuildNoOpStrategy() {
+        assertThat(ExecutionStrategies.noOp())
+                .isExactlyInstanceOf(ExecutionStrategies.NoOpExecutionStrategy.class);
+    }
+
+    @Test
+    void shouldBuildSystemExitStrategy() {
+        var strategy = ExecutionStrategies.systemExit();
+        var systemExitStrategy = assertIsExactType(strategy, ExecutionStrategies.SystemExitExecutionStrategy.class);
+        assertThat(systemExitStrategy.getExitCode()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldBuildSystemExitStrategyWithExitCode() {
+        var strategy = ExecutionStrategies.systemExit(42);
+        var systemExitStrategy = assertIsExactType(strategy, ExecutionStrategies.SystemExitExecutionStrategy.class);
+        assertThat(systemExitStrategy.getExitCode()).isEqualTo(42);
+    }
+
+    @Nested
+    class NoOpStrategy {
+
+        @Test
+        void shouldDoNothing() {
+            var executionStrategy = ExecutionStrategies.noOp();
+            assertThatCode(executionStrategy::exit).doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    class ExitFlaggingStrategy {
+
+        @Test
+        void shouldFlagCallsToExit() {
+            var executionStrategy = ExecutionStrategies.exitFlagging();
+            assertThatCode(executionStrategy::exit).doesNotThrowAnyException();
+
+            var exitFlaggingStrategy =
+                    assertIsExactType(executionStrategy, ExecutionStrategies.ExitFlaggingExecutionStrategy.class);
+            assertThat(exitFlaggingStrategy.didExit()).isTrue();
+        }
+
+        @Test
+        void shouldNotFlagWhenExitNotCalled() {
+            var exitFlaggingStrategy =
+                    assertIsExactType(ExecutionStrategies.exitFlagging(), ExecutionStrategies.ExitFlaggingExecutionStrategy.class);
+            assertThat(exitFlaggingStrategy.didExit()).isFalse();
+        }
+    }
+
+    @Nested
+    class SystemExitStrategy {
+
+        @ParameterizedTest
+        @CsvSource({
+                "1, 0",
+                "143 , 0",
+                "127, 25",
+                "143, 50"
+        })
+        void shouldExitTheJVM(int exitCode, long exitWaitDelayMillis) throws IOException {
+            var result = execTestApplication(exitCode, exitWaitDelayMillis);
+
+            assertThat(result.pid).isPositive();
+            assertThat(result.exitValue).isEqualTo(exitCode);
+        }
+    }
+
+    @Slf4j
+    public static class TestApplication {
+        public static void main(String[] args) {
+            int exitCode = Integer.parseInt(args[0]);
+            long exitWaitDelayMillis = Long.parseLong(args[1]);
+            LOG.debug("Using exitCode: {} ; exitWaitDelayMillis: {}", exitCode, exitWaitDelayMillis);
+
+            // pretend some unrecoverable error occurred...
+            var executionStrategy = ExecutionStrategies.systemExit(exitCode);
+            new SystemExecutioner(executionStrategy).exit(exitWaitDelayMillis, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static ExecResult execTestApplication(int exitCode, long exitWaitDelayMillis) throws IOException {
+        var javaHome = System.getProperty("java.home");
+        var javaBin = Path.of(javaHome, "bin", "java").toString();
+        var classpath = System.getProperty("java.class.path");
+        var className = TestApplication.class.getName();
+        var command = List.of(javaBin,
+                "-cp", classpath,
+                className,
+                String.valueOf(exitCode),
+                String.valueOf(exitWaitDelayMillis));
+
+        var process = new ProcessBuilder(command).start();
+        var exitValueOrNull = Processes.waitForExit(process, 1, TimeUnit.SECONDS).orElse(null);
+        return new ExecResult(process.pid(), exitValueOrNull);
+    }
+
+    @Value
+    private static class ExecResult {
+        long pid;
+        Integer exitValue;
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategiesTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategiesTest.java
@@ -120,12 +120,13 @@ class ExecutionStrategiesTest {
 
         LOG.debug("Executing TestApplication using {} with exitCode {} and exitWaitDelayMillis {}",
                 javaBin, exitCode, exitWaitDelayMillis);
+        long start = System.nanoTime();
         var process = new ProcessBuilder(command).start();
         var exitValueOrNull = Processes.waitForExit(process, 5, TimeUnit.SECONDS).orElse(null);
-        var execResult = new ExecResult(process.pid(), exitValueOrNull);
-        LOG.debug("Received result: {}", execResult);
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+        LOG.debug("After {} ms, received exit value {} for process {}", elapsedMillis, exitValueOrNull, process.pid());
 
-        return execResult;
+        return new ExecResult(process.pid(), exitValueOrNull);
     }
 
     @Value

--- a/src/test/java/org/kiwiproject/dropwizard/util/startup/SystemExecutionerTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/startup/SystemExecutionerTest.java
@@ -1,0 +1,110 @@
+package org.kiwiproject.dropwizard.util.startup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Durations.ONE_SECOND;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.base.DefaultEnvironment;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+@DisplayName("SystemExecutioner")
+@Slf4j
+class SystemExecutionerTest {
+
+    @Test
+    void shouldUseSystemExitStrategyByDefault() {
+        var executioner = new SystemExecutioner();
+        assertThat(executioner.getExecutionStrategy())
+                .isExactlyInstanceOf(ExecutionStrategies.SystemExitExecutionStrategy.class);
+    }
+
+    @Test
+    void shouldExitImmediately() {
+        var executionStrategy = new ExecutionStrategies.ExitFlaggingExecutionStrategy();
+        var executioner = new SystemExecutioner(executionStrategy);
+        long startTime = System.nanoTime();
+        executioner.exit();
+        var elapsedNanos = System.nanoTime() - startTime;
+
+        assertThat(executionStrategy.didExit()).isTrue();
+
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
+        LOG.info("elapsedMillis: {} (elapsedNanos: {})", elapsedMillis, elapsedNanos);
+        assertThat(elapsedMillis).isZero();
+    }
+
+    @Test
+    void shouldExitWithWaitTime() {
+        var executorService = Executors.newSingleThreadExecutor();
+
+        var waitTimeMillis = 25;
+        var executionStrategy = new ExecutionStrategies.ExitFlaggingExecutionStrategy();
+        var executioner = new SystemExecutioner(executionStrategy);
+        var startTime = new AtomicLong();
+
+        var executionFuture = executorService.submit(() -> {
+            LOG.info("Calling executioner...");
+            startTime.set(System.nanoTime());
+            executioner.exit(waitTimeMillis, TimeUnit.MILLISECONDS);
+        });
+
+        await().atMost(ONE_SECOND).until(executionFuture::isDone);
+
+        long elapsedNanos = System.nanoTime() - startTime.get();
+
+        assertThat(executionStrategy.didExit())
+                .describedAs("Execution strategy exit() should have been called")
+                .isTrue();
+
+        assertThat(TimeUnit.NANOSECONDS.toMillis(elapsedNanos))
+                .describedAs("Elapsed millis must be greater than %d", waitTimeMillis)
+                .isGreaterThan(waitTimeMillis);
+
+        executorService.shutdown();
+        await().atMost(ONE_SECOND).until(executorService::isShutdown);
+    }
+
+    @Test
+    void shouldExitBeforeGivenWaitTime_WhenWaitingThreadInterrupted() {
+        var executorService = Executors.newFixedThreadPool(2);
+
+        var executionStrategy = new ExecutionStrategies.ExitFlaggingExecutionStrategy();
+        var executioner = new SystemExecutioner(executionStrategy);
+        var startTime = new AtomicLong();
+        var executionFuture = executorService.submit(() -> {
+            LOG.info("Calling executioner with 5 second wait");
+            startTime.set(System.nanoTime());
+            executioner.exit(5, TimeUnit.SECONDS);
+        });
+
+        var killerSleepTimeMillis = 100;
+        var killerFuture = executorService.submit(() -> {
+            LOG.info("Sleeping for {} milliseconds...", killerSleepTimeMillis);
+            new DefaultEnvironment().sleepQuietly(killerSleepTimeMillis, TimeUnit.MILLISECONDS);
+            LOG.info("I'm awake and will now interrupt executionThread");
+            var canceled = executionFuture.cancel(true);
+            LOG.info("executionFuture was canceled? {}", canceled);
+        });
+
+        await().atMost(ONE_SECOND).until(() -> executionFuture.isDone() && killerFuture.isDone());
+
+        long elapsedNanos = System.nanoTime() - startTime.get();
+
+        assertThat(executionStrategy.didExit())
+                .describedAs("Execution strategy exit() should have been called")
+                .isTrue();
+
+        assertThat(TimeUnit.NANOSECONDS.toMillis(elapsedNanos))
+                .describedAs("Elapsed millis must be greater than %d", killerSleepTimeMillis)
+                .isGreaterThan(killerSleepTimeMillis);
+
+        executorService.shutdown();
+        await().atMost(ONE_SECOND).until(executorService::isShutdown);
+    }
+}


### PR DESCRIPTION
* Introduce ExecutionStrategy interface as a pluggable strategy for
  terminating the JVM (or not terminating in tests, etc.)
* ExecutionStrategies is a factory class that provides several
  strategies: a no-op strategy, an exit "flagging" strategy, and a
  System.exit strategy.
* SystemExecutioner remains backward-compatible since the no-args
  constructor uses the System.exit strategy but provides a way
  to construct an instance with some other ExecutionStrategy. This will
  mainly be useful in testing situations.
* Note also that even though Jacoco will say the exit() method of
  SystemExitExecutionStrategy is not covered by tests, it actually *is*
  covered because ExecutionStrategiesTest actually launches a separate
  JVM and verifies that it was exited.