### PR TITLE
Rework MonitoredJobs to fix bug when setting error handler or timeout

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/job/JobErrorHandlers.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/job/JobErrorHandlers.java
@@ -1,0 +1,73 @@
+package org.kiwiproject.dropwizard.util.job;
+
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+
+/**
+ * Factory for a few simple {@link JobErrorHandler} implementations.
+ */
+@UtilityClass
+public class JobErrorHandlers {
+
+    private static final String LOG_MESSAGE_TEMPLATE = "Job '{}' threw an exception";
+
+    /**
+     * A no-op error handler.
+     *
+     * @return a {@link JobErrorHandler} that does nothing at all
+     */
+    public static JobErrorHandler noOpHandler() {
+        return new NoOpJobErrorHandler();
+    }
+
+    /**
+     * An error handler that logs the job name and exception at WARN level.
+     *
+     * @return a {@link JobErrorHandler} that logs errors
+     */
+    public static JobErrorHandler loggingHandler() {
+        return new LoggingJobErrorHandler();
+    }
+
+    /**
+     * An error handler that logs the job name and exception at WARN level using the given {@link Logger}.
+     * <p>
+     * Prefer this over {@link #loggingHandler()} when you want or need control of the {@link Logger} to use.
+     *
+     * @param logger the SLF4J logger to log with
+     * @return a {@link JobErrorHandler} that logs errors
+     */
+    public static JobErrorHandler loggingHandler(Logger logger) {
+        return new CustomLoggerJobErrorHandler(logger);
+    }
+
+    private static class NoOpJobErrorHandler implements JobErrorHandler {
+        @Override
+        public void handle(MonitoredJob job, Throwable throwable) {
+            // no-op
+        }
+    }
+
+    @Slf4j
+    private static class LoggingJobErrorHandler implements JobErrorHandler {
+        @Override
+        public void handle(MonitoredJob job, Throwable throwable) {
+            LOG.warn(LOG_MESSAGE_TEMPLATE, job.getName(), throwable);
+        }
+    }
+
+    private static class CustomLoggerJobErrorHandler implements JobErrorHandler {
+
+        private final Logger customLogger;
+
+        private CustomLoggerJobErrorHandler(Logger customLogger) {
+            this.customLogger = customLogger;
+        }
+
+        @Override
+        public void handle(MonitoredJob job, Throwable throwable) {
+            customLogger.warn(LOG_MESSAGE_TEMPLATE, job.getName(), throwable);
+        }
+    }
+}

--- a/src/main/java/org/kiwiproject/dropwizard/util/job/MonitoredJob.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/job/MonitoredJob.java
@@ -10,7 +10,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.SneakyThrows;
-import lombok.With;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.BooleanUtils;
 import org.kiwiproject.base.CatchingRunnable;
@@ -30,10 +29,8 @@ public class MonitoredJob implements CatchingRunnable {
 
     private final Runnable task;
 
-    @With
     private final JobErrorHandler errorHandler;
 
-    @With
     private final Duration timeout;
 
     @Getter
@@ -67,7 +64,7 @@ public class MonitoredJob implements CatchingRunnable {
         this.name = requireNotBlank(name, "name is required");
         this.task = requireNotNull(task, "task is required");
         this.decisionFunction = isNull(decisionFunction) ? (job -> true) : decisionFunction;
-        this.errorHandler = errorHandler;
+        this.errorHandler = isNull(errorHandler) ? JobErrorHandlers.noOpHandler() : errorHandler;
         this.timeout = timeout;
         this.environment = isNull(environment) ? new DefaultEnvironment() : environment;
     }

--- a/src/test/java/org/kiwiproject/dropwizard/util/job/JobErrorHandlersTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/job/JobErrorHandlersTest.java
@@ -1,0 +1,52 @@
+package org.kiwiproject.dropwizard.util.job;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+
+@DisplayName("JobErrorHandlers")
+@Slf4j
+class JobErrorHandlersTest {
+
+    @Test
+    void shouldCreateNoOpHandler() {
+        var handler = JobErrorHandlers.noOpHandler();
+        assertThatCode(() -> handler.handle(null, null))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldCreateLoggingHandler() {
+        var handler = JobErrorHandlers.loggingHandler();
+
+        var job = MonitoredJob.builder()
+                .name("test task")
+                .task(() -> LOG.info("Executing task"))
+                .build();
+
+        assertThatCode(() -> handler.handle(job, new RuntimeException("an oop happened")))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldCreateLoggingHandler_UsingCustomLogger() {
+        var logger = mock(Logger.class);
+        var handler = JobErrorHandlers.loggingHandler(logger);
+
+        var job = MonitoredJob.builder()
+                .name("test task")
+                .task(() -> LOG.info("Executing task"))
+                .build();
+
+        var exception = new RuntimeException("an oop happened");
+        assertThatCode(() -> handler.handle(job, exception))
+                .doesNotThrowAnyException();
+
+        verify(logger).warn("Job '{}' threw an exception", "test task", exception);
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobTest.java
@@ -57,35 +57,6 @@ class MonitoredJobTest {
             assertThat(job.getDecisionFunction()).isNotNull();
             assertThat(job.getEnvironment()).isNotNull();
         }
-
-        @Test
-        void shouldAllowErrorHandlerToBeSet() {
-            var job = MonitoredJob.builder()
-                    .name("Name and Task Job")
-                    .task(() -> System.out.println("Hello"))
-                    .build();
-
-            var handler = new JobErrorHandler() {
-                @Override
-                public void handle(MonitoredJob job, Throwable throwable) {
-                    // Intentionally blank
-                }
-            };
-
-            var enhancedJob = job.withErrorHandler(handler);
-            assertThat(enhancedJob).isNotSameAs(job);
-        }
-
-        @Test
-        void shouldAllowTimeoutToBeSet() {
-            var job = MonitoredJob.builder()
-                    .name("Name and Task Job")
-                    .task(() -> System.out.println("Hello"))
-                    .build();
-
-            var enhancedJob = job.withTimeout(Duration.ofSeconds(1));
-            assertThat(enhancedJob).isNotSameAs(job);
-        }
     }
 
     @Nested

--- a/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobsTest.java
@@ -2,6 +2,7 @@ package org.kiwiproject.dropwizard.util.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -12,21 +13,28 @@ import static org.mockito.Mockito.when;
 import io.dropwizard.lifecycle.setup.ScheduledExecutorServiceBuilder;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Duration;
+import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.awaitility.Durations;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.kiwiproject.base.KiwiEnvironment;
 import org.kiwiproject.dropwizard.util.config.JobSchedule;
 import org.kiwiproject.dropwizard.util.health.MonitoredJobHealthCheck;
 import org.kiwiproject.test.dropwizard.mockito.DropwizardMockitoMocks;
 
+import java.time.Instant;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @DisplayName("MonitoredJobs")
 @ExtendWith(SoftAssertionsExtension.class)
+@Slf4j
 class MonitoredJobsTest {
 
     private Environment env;
@@ -43,6 +51,7 @@ class MonitoredJobsTest {
         class ShouldThrowIllegalArgument {
 
             private Runnable task;
+            private JobSchedule schedule;
 
             @BeforeEach
             void setUp() {
@@ -54,6 +63,10 @@ class MonitoredJobsTest {
                 when(scheduledExecutorServiceBuilder.build()).thenReturn(mock(ScheduledExecutorService.class));
 
                 task = () -> System.out.println("hello");
+
+                schedule = JobSchedule.builder()
+                        .intervalDelay(Duration.minutes(5))
+                        .build();
             }
 
             @Test
@@ -90,6 +103,58 @@ class MonitoredJobsTest {
                         .isThrownBy(() -> MonitoredJobs.registerJob(env, jobName,
                                 new JobSchedule(), task))
                         .withMessage("Job '%s' must specify a non-null interval delay", jobName);
+            }
+
+            @Nested
+            class UsingBuilder {
+
+                @Test
+                void whenMissingName() {
+                    var builder = MonitoredJobs.builder()
+                            .task(task)
+                            .environment(env)
+                            .schedule(schedule);
+
+                    assertThatIllegalArgumentException()
+                            .isThrownBy(builder::registerJob)
+                            .withMessage("non-blank name is required");
+                }
+
+                @Test
+                void whenMissingTask() {
+                    var builder = MonitoredJobs.builder()
+                            .name("test task")
+                            .environment(env)
+                            .schedule(schedule);
+
+                    assertThatIllegalArgumentException()
+                            .isThrownBy(builder::registerJob)
+                            .withMessage("task is required");
+                }
+
+                @Test
+                void whenMissingEnvironment() {
+                    var builder = MonitoredJobs.builder()
+                            .name("test task")
+                            .task(task)
+                            .schedule(schedule);
+
+                    assertThatIllegalArgumentException()
+                            .isThrownBy(builder::registerJob)
+                            .withMessage("environment is required");
+                }
+
+                @Test
+                void whenMissingSchedule() {
+                    var builder = MonitoredJobs.builder()
+                            .name("test task")
+                            .task(task)
+                            .environment(env);
+
+                    assertThatIllegalArgumentException()
+                            .isThrownBy(builder::registerJob)
+                            .withMessage("schedule is required");
+                }
             }
         }
 
@@ -153,11 +218,73 @@ class MonitoredJobsTest {
                 assertThat(monitoredJob).isSameAs(job);
             }
 
+            @Test
+            void whenUsingBuilder() {
+                var kiwiEnv = mock(KiwiEnvironment.class);
+
+                var job = MonitoredJobs.builder()
+                        .name("ValidJob")
+                        .task(task)
+                        .environment(env)
+                        .schedule(schedule)
+                        .timeout(Duration.seconds(30))
+                        .errorHandler(JobErrorHandlers.loggingHandler())
+                        .decisionFunction(this::executedMoreThanFiveMinutesAgo)
+                        .kiwiEnvironment(kiwiEnv)
+                        .registerJob();
+
+                assertAndVerifyJob(job);
+            }
+
+            private boolean executedMoreThanFiveMinutesAgo(MonitoredJob job) {
+                var now = System.currentTimeMillis();
+                var lastExecuted = job.getLastExecutionTime().get();
+                var millisSinceLastExecuted = now - lastExecuted;
+                return millisSinceLastExecuted > TimeUnit.MINUTES.toMillis(5);
+            }
+
+            @Test
+            void whenUsingBuilderWithCustomExecutor() throws InterruptedException {
+                var count = new AtomicInteger();
+                Runnable countingTask = count::incrementAndGet;
+                var executor = Executors.newSingleThreadScheduledExecutor();
+                var fastSchedule = JobSchedule.builder()
+                        .initialDelay(Duration.seconds(0))
+                        .intervalDelay(Duration.seconds(1))
+                        .build();
+
+                try {
+                    var job = MonitoredJobs.builder()
+                            .name("FastJob1234")
+                            .task(countingTask)
+                            .environment(env)
+                            .schedule(fastSchedule)
+                            .executor(executor)
+                            .registerJob();
+
+                    await().atMost(Durations.TWO_SECONDS).until(() -> count.get() >= 1);
+
+                    assertThat(job.getLastSuccess()).hasValueGreaterThan(Instant.now().minusSeconds(2).toEpochMilli());
+                    assertThat(job.getLastFailure()).hasValue(0);
+                    assertThat(job.getFailureCount()).hasValue(0);
+                    assertHealthCheckWasRegistered(job);
+                } finally {
+                    executor.shutdown();
+                    var terminatedOk = executor.awaitTermination(100, TimeUnit.MILLISECONDS);
+                    LOG.info("terminatedOk? {}", terminatedOk);
+                }
+            }
+
             private void assertAndVerifyJob(MonitoredJob job) {
                 assertThat(job).isNotNull();
 
-                verify(env.healthChecks()).register(eq("Job: ValidJob"), any(MonitoredJobHealthCheck.class));
+                assertHealthCheckWasRegistered(job);
                 verify(executor).scheduleWithFixedDelay(job, 10, 30, TimeUnit.SECONDS);
+            }
+
+            private void assertHealthCheckWasRegistered(MonitoredJob job) {
+                verify(env.healthChecks())
+                        .register(eq("Job: " + job.getName()), any(MonitoredJobHealthCheck.class));
             }
         }
     }


### PR DESCRIPTION
* Remove the withErrorHandler and withTimeout methods from
  MonitoredJob which did not actually set the error handler or timeout
  since they always created a new instance
* Create a custom builder in MonitoredJobs. We cannot use Lombok for
  various reasons, mainly that we want to create an instance of
  MonitoredJob not MonitoredJobs, and we want the terminal operation to
  be named registerJob() instead of build().
* Add JobErrorHandlers as a static factory for several simple
  JobErrorHandler implementations

Closes #100
Closes #106