### PR TITLE
Add registerJob factory method that accepts MonitoredJob and JobSchedule

### DIFF
--- a/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobsTest.java
@@ -206,7 +206,20 @@ class MonitoredJobsTest {
             }
 
             @Test
-            void whenGivenAMonitoredJob() {
+            void whenGivenAMonitoredJob_ButNoExecutor() {
+                var job = MonitoredJob.builder()
+                        .name("ValidJob")
+                        .task(task)
+                        .build();
+
+                var monitoredJob = MonitoredJobs.registerJob(env, job, schedule);
+
+                assertAndVerifyJob(job);
+                assertThat(monitoredJob).isSameAs(job);
+            }
+
+            @Test
+            void whenGivenAMonitoredJob_AndExecutor() {
                 var job = MonitoredJob.builder()
                         .name("ValidJob")
                         .task(task)


### PR DESCRIPTION
This method does NOT accept a ScheduledExecutorService and instead
creates one internally.

Other misc:

* Add some more javadocs
* Rename buildScheduledExecutor to newScheduledExecutor and move it
  to the bottom, since the last method in this class uses it

Closes #108