### PR TITLE
Handle InterruptedException in ServerLoadFetcher

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/metrics/ServerLoadFetcher.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/metrics/ServerLoadFetcher.java
@@ -64,6 +64,10 @@ public class ServerLoadFetcher {
             }
 
             return Optional.of(matcher.group(1));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Interrupted while getting server load average", e);
+            return Optional.empty();
         } catch (Exception e) {
             LOG.debug("Error getting server load average", e);
             return Optional.empty();


### PR DESCRIPTION
* Add catch block for InterruptedException in ServerLoadFetcher and
  reset the interrupt status, per Sonar rule java:S2142
* I did not add a test for this b/c that would involve the code under
  test actually setting the interrupt status of the current Thread,
  which I don't think is a good idea (need to investigate whether this
  can be done safely in tests...)