### PR TITLE
Update dependencies; updates for breaking kiwi 0.21.0 changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,11 +30,11 @@
     <properties>
         <!-- Versions for required dependencies -->
         <dropwizard.version>2.0.20</dropwizard.version>
-        <dropwizard-curator.version>0.17.0</dropwizard-curator.version>
+        <dropwizard-curator.version>0.18.0</dropwizard-curator.version>
         <kiwi.version>0.21.0</kiwi.version>
         <jackson.version>[2.10.5,2.10.6)</jackson.version>
         <metrics-healthchecks-severity.version>0.18.0</metrics-healthchecks-severity.version>
-        <service-discovery-client.version>0.14.0</service-discovery-client.version>
+        <service-discovery-client.version>0.15.0</service-discovery-client.version>
         <zookeeper.version>3.4.14</zookeeper.version>
 
         <!-- Versions for provided dependencies -->
@@ -44,7 +44,7 @@
         <metrics-servlets.version>4.1.18</metrics-servlets.version>
         <metrics-jetty9>4.1.18</metrics-jetty9>
         <mongo.version>3.12.8</mongo.version>
-        <registry-aware-jersey-client>0.12.0</registry-aware-jersey-client>
+        <registry-aware-jersey-client>0.13.0</registry-aware-jersey-client>
 
         <!-- Versions for optional dependencies -->
 

--- a/src/main/java/org/kiwiproject/dropwizard/util/job/JobErrorHandler.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/job/JobErrorHandler.java
@@ -6,10 +6,10 @@ package org.kiwiproject.dropwizard.util.job;
 public interface JobErrorHandler {
 
     /**
-     * Handles a {@link Throwable} that occurred during the run of the {@link MonitoredJob}.
+     * Handles an {@link Exception} that occurred during the run of the {@link MonitoredJob}.
      *
      * @param job       the job that was run
-     * @param throwable the error that occurred
+     * @param exception the error that occurred
      */
-    void handle(MonitoredJob job, Throwable throwable);
+    void handle(MonitoredJob job, Exception exception);
 }

--- a/src/main/java/org/kiwiproject/dropwizard/util/job/JobErrorHandlers.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/job/JobErrorHandlers.java
@@ -44,7 +44,7 @@ public class JobErrorHandlers {
 
     private static class NoOpJobErrorHandler implements JobErrorHandler {
         @Override
-        public void handle(MonitoredJob job, Throwable throwable) {
+        public void handle(MonitoredJob job, Exception exception) {
             // no-op
         }
     }
@@ -52,8 +52,8 @@ public class JobErrorHandlers {
     @Slf4j
     private static class LoggingJobErrorHandler implements JobErrorHandler {
         @Override
-        public void handle(MonitoredJob job, Throwable throwable) {
-            LOG.warn(LOG_MESSAGE_TEMPLATE, job.getName(), throwable);
+        public void handle(MonitoredJob job, Exception exception) {
+            LOG.warn(LOG_MESSAGE_TEMPLATE, job.getName(), exception);
         }
     }
 
@@ -66,8 +66,8 @@ public class JobErrorHandlers {
         }
 
         @Override
-        public void handle(MonitoredJob job, Throwable throwable) {
-            customLogger.warn(LOG_MESSAGE_TEMPLATE, job.getName(), throwable);
+        public void handle(MonitoredJob job, Exception exception) {
+            customLogger.warn(LOG_MESSAGE_TEMPLATE, job.getName(), exception);
         }
     }
 }

--- a/src/main/java/org/kiwiproject/dropwizard/util/job/MonitoredJob.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/job/MonitoredJob.java
@@ -170,13 +170,13 @@ public class MonitoredJob implements CatchingRunnable {
     }
 
     @Override
-    public void handleExceptionSafely(Throwable throwable) {
+    public void handleExceptionSafely(Exception exception) {
         LOG.warn("Encountered exception in job: {}", name);
         lastFailure.set(environment.currentTimeMillis());
         failureCount.incrementAndGet();
 
         if (nonNull(errorHandler)) {
-            errorHandler.handle(this, throwable);
+            errorHandler.handle(this, exception);
         }
     }
 }

--- a/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobTest.java
@@ -167,7 +167,7 @@ class MonitoredJobTest {
             var taskHandledCount = new AtomicInteger();
             var handler = new JobErrorHandler() {
                 @Override
-                public void handle(MonitoredJob job, Throwable throwable) {
+                public void handle(MonitoredJob job, Exception exception) {
                     taskHandledCount.incrementAndGet();
                 }
             };
@@ -192,7 +192,7 @@ class MonitoredJobTest {
         void shouldNotAllowExceptionsThrownByErrorHandlerToEscape() {
             var handler = new JobErrorHandler() {
                 @Override
-                public void handle(MonitoredJob job, Throwable throwable) {
+                public void handle(MonitoredJob job, Exception exception) {
                     throw new RuntimeException("error handling error");
                 }
             };


### PR DESCRIPTION
* Update Throwable to Exception in MonitoredJob due to breaking changes
  in kiwi 0.21.0 which changed CatchingRunnable to only handle Exception
  and not Throwable
* Change JobErrorHandler and JobErrorHandlers to only handle Exception
  for the same reason kiwi changed CatchingRunnable; Throwable should
  not be caught by application code, since it could also catch Error
  subclasses such as OutOfMemoryError, etc.

Dependency updates:
* Bump dropwizard-curator from 0.17.0 to 0.18.0
* Bump service-discovery-client from 0.14.0 to 0.15.0
* Bump registry-aware-jersey-client from 0.12.0 to 0.13.0

Closes #115
Closes #123
Closes #124
Closes #125