### PR TITLE
AllowablePortRange should not allow zero as a valid (minimum) port

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/AllowablePortRange.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/AllowablePortRange.java
@@ -1,12 +1,12 @@
 package org.kiwiproject.dropwizard.util.startup;
 
 import static com.google.common.base.Preconditions.checkState;
-import static org.kiwiproject.base.KiwiPreconditions.requireValidPort;
+import static org.kiwiproject.base.KiwiPreconditions.requireValidNonZeroPort;
 
 import lombok.Getter;
 
 /**
- * Defines the allowable port range for a service to bind to, in situations where there is a restriction.
+ * Defines the allowable port range for a service to bind to, for situations where there is a restriction.
  */
 @Getter
 public class AllowablePortRange {
@@ -26,10 +26,14 @@ public class AllowablePortRange {
      * @throws IllegalStateException if the minPortNumber is greater than or equal to the maxPortNumber or if either port is not valid
      */
     public AllowablePortRange(int minPortNumber, int maxPortNumber) {
-        checkState(minPortNumber < maxPortNumber, "minPortNumber must be less than maxPortNumber");
+        checkState(minPortNumber < maxPortNumber,
+                "minPortNumber must be less than maxPortNumber (was: %s -> %s)", minPortNumber, maxPortNumber);
 
-        this.minPortNumber = requireValidPort(minPortNumber);
-        this.maxPortNumber = requireValidPort(maxPortNumber);
+        this.minPortNumber = requireValidNonZeroPort(minPortNumber,
+                "minPort must be between 1 and 65534 (was: %s)", minPortNumber);
+
+        this.maxPortNumber = requireValidNonZeroPort(maxPortNumber,
+                "maxPort must be between 2 and 65535 (was: %s)", maxPortNumber);
 
         this.numPortsInRange = 1 + (maxPortNumber - minPortNumber);
         this.maxPortCheckAttempts = RANGE_MULTIPLIER * numPortsInRange;


### PR DESCRIPTION
* Don't allow zero as a minimum port (also checks maximum but that
  can't happen due to the initial check that min < max port)
* Update the exception messages to be more clear and meaningful, and
  include the actual values in the messages for easier debugging and/or
  troubleshooting
* Update tests that were not parameterized to be parameterized

Closes #162