### PR TITLE
Make fields final in AllowablePortRange

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/AllowablePortRange.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/AllowablePortRange.java
@@ -13,10 +13,10 @@ public class AllowablePortRange {
 
     private static final int RANGE_MULTIPLIER = 3;
 
-    int minPortNumber;
-    int maxPortNumber;
-    int numPortsInRange;
-    int maxPortCheckAttempts;
+    final int minPortNumber;
+    final int maxPortNumber;
+    final int numPortsInRange;
+    final int maxPortCheckAttempts;
 
     /**
      * Creates a new AllowablePortRange


### PR DESCRIPTION
* Make the fields in AllowablePortRange final, but leaving them as
  package-private for the moment; they are accessed by PortAssigner
  which is in the same package, so I don't have too much heartburn
  over this.