### PR TITLE
Change MonitoredJobs to convert delays to nanoseconds when scheduling

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/job/MonitoredJobs.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/job/MonitoredJobs.java
@@ -171,9 +171,14 @@ public class MonitoredJobs {
     }
 
     private static void scheduleJob(ScheduledExecutorService executor, JobSchedule schedule, MonitoredJob job) {
-        LOG.debug("Scheduling job: {} to run every: {}", job.getName(), schedule.getIntervalDelay());
-        executor.scheduleWithFixedDelay(job, schedule.getInitialDelay().toSeconds(),
-                schedule.getIntervalDelay().toSeconds(), TimeUnit.SECONDS);
+        LOG.debug("Scheduling job: {} to start after initial delay: {} and run every: {}",
+                job.getName(), schedule.getInitialDelay(), schedule.getIntervalDelay());
+
+        executor.scheduleWithFixedDelay(
+                job,
+                schedule.getInitialDelay().toNanoseconds(),
+                schedule.getIntervalDelay().toNanoseconds(),
+                TimeUnit.NANOSECONDS);
     }
 
     /**

--- a/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobsTest.java
@@ -289,7 +289,11 @@ class MonitoredJobsTest {
                 assertThat(job).isNotNull();
 
                 assertHealthCheckWasRegistered(job);
-                verify(executor).scheduleWithFixedDelay(job, 10, 30, TimeUnit.SECONDS);
+
+                var expectedInitialDelay = schedule.getInitialDelay().toNanoseconds();
+                var expectedIntervalDelay = schedule.getIntervalDelay().toNanoseconds();
+
+                verify(executor).scheduleWithFixedDelay(job, expectedInitialDelay, expectedIntervalDelay, TimeUnit.NANOSECONDS);
             }
 
             private void assertHealthCheckWasRegistered(MonitoredJob job) {


### PR DESCRIPTION
This avoids problems if callers want to schedule more granular than one
second. For example, with initial delay of 100 milliseconds and interval
delay of 200 milliseconds, converting to seconds results in both values
being zero in the original code. By converting the delays to nanoseconds
instead, we ensure this problem won't happen.

Fixes #173