### PR TITLE
Change timing assertion in SystemExecutionerTest

### DIFF
--- a/src/test/java/org/kiwiproject/dropwizard/util/startup/SystemExecutionerTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/startup/SystemExecutionerTest.java
@@ -100,9 +100,11 @@ class SystemExecutionerTest {
                 .describedAs("Execution strategy exit() should have been called")
                 .isTrue();
 
-        assertThat(TimeUnit.NANOSECONDS.toMillis(elapsedNanos))
-                .describedAs("Elapsed millis must be greater than %d", killerSleepTimeMillis)
-                .isGreaterThan(killerSleepTimeMillis);
+        var elapsedMillis = TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
+        LOG.info("Actual elapsed time: {} nanoseconds ; {} milliseconds", elapsedNanos, elapsedMillis);
+        assertThat(elapsedMillis)
+                .describedAs("Elapsed millis must be at least %d", killerSleepTimeMillis)
+                .isGreaterThanOrEqualTo(killerSleepTimeMillis);
 
         executorService.shutdown();
         await().atMost(ONE_SECOND).until(executorService::isShutdown);


### PR DESCRIPTION
* Change shouldExitBeforeGivenWaitTime_WhenWaitingThreadInterrupted to
  use isGreaterThanOrEqualTo instead of isGreaterThan
* Add an INFO level log just to see what the nanos and conversion to
  milliseconds were during a test run

Closes #183