### PR TITLE
Miscellaneous code cleanup

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/health/MongoHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/MongoHealthCheck.java
@@ -31,7 +31,7 @@ public class MongoHealthCheck extends HealthCheck {
 
     @SuppressWarnings({"deprecation", "ConstantConditions"})
     @Override
-    protected Result check() throws Exception {
+    protected Result check() {
         var host = db.getMongo().getAddress().toString();
         var dbName = db.getName();
 

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/MonitoredJobHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/MonitoredJobHealthCheck.java
@@ -8,8 +8,6 @@ import static org.kiwiproject.metrics.health.HealthCheckResults.newResultBuilder
 import static org.kiwiproject.metrics.health.HealthCheckResults.newUnhealthyResult;
 import static org.kiwiproject.metrics.health.HealthCheckResults.newUnhealthyResultBuilder;
 
-import java.time.Instant;
-
 import com.codahale.metrics.health.HealthCheck;
 import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.util.Duration;
@@ -20,6 +18,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.kiwiproject.base.DefaultEnvironment;
 import org.kiwiproject.base.KiwiEnvironment;
 import org.kiwiproject.dropwizard.util.job.MonitoredJob;
+
+import java.time.Instant;
 
 /**
  * Health check that monitors a {@link MonitoredJob} to ensure that it is running on schedule and not encountering
@@ -115,7 +115,7 @@ public class MonitoredJobHealthCheck extends HealthCheck {
     }
 
     @Override
-    protected Result check() throws Exception {
+    protected Result check() {
         try {
             var lastRun = job.getLastSuccess().get();
             if (!job.isActive()) {

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/ServerErrorHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/ServerErrorHealthCheck.java
@@ -69,7 +69,7 @@ public class ServerErrorHealthCheck extends HealthCheck {
     }
 
     @Override
-    protected Result check() throws Exception {
+    protected Result check() {
         var meters = metrics.getMeters(METRIC_FILTER);
 
         if (isNullOrEmpty(meters) || !meters.containsKey(METER_NAME)) {

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/ServicePingHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/ServicePingHealthCheck.java
@@ -95,7 +95,7 @@ public class ServicePingHealthCheck extends HealthCheck {
     }
 
     @Override
-    protected Result check() throws Exception {
+    protected Result check() {
         WebTarget target;
 
         try {
@@ -180,7 +180,7 @@ public class ServicePingHealthCheck extends HealthCheck {
      * Registers a {@link ServicePingHealthCheck} for each of the given {@link ServiceIdentifier}s given, using the
      * given importance <em>for each</em>.
      * <p>
-     * NOTE: If different importances are required for different services, then call this method for each importance.
+     * NOTE: If different importance is required for different services, then call this method for each importance.
      *
      * @param healthCheckRegistry the {@link HealthCheckRegistry} to register the health checks.
      * @param client              the {@link RegistryAwareClient} to use for service lookup and to perform the request.

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/UnknownPropertiesHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/UnknownPropertiesHealthCheck.java
@@ -29,7 +29,7 @@ public class UnknownPropertiesHealthCheck extends HealthCheck {
     }
 
     @Override
-    protected Result check() throws Exception {
+    protected Result check() {
         if (handler.getUnknownPropertyCount() == 0) {
             return newHealthyResult("No unknown properties detected");
         }

--- a/src/test/java/org/kiwiproject/dropwizard/util/health/HttpConnectionsHealthCheckTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/health/HttpConnectionsHealthCheckTest.java
@@ -78,7 +78,7 @@ class HttpConnectionsHealthCheckTest {
             @SuppressWarnings({"unchecked", "rawtypes"})
             @Test
             void whenOneDropwizardJerseyClient_ThatIsBelowDefaultWarningThreshold() {
-                SortedMap<String, Gauge> gauges = (TreeMap) KiwiMaps.newTreeMap(
+                SortedMap<String, Gauge> gauges = KiwiMaps.newTreeMap(
                         leasedGaugeNameFor("some-client"), gaugeReturning(4),
                         maxGaugeNameFor("some-client"), gaugeReturning(10)
                 );
@@ -110,7 +110,7 @@ class HttpConnectionsHealthCheckTest {
             @SuppressWarnings({"unchecked", "rawtypes"})
             @Test
             void whenMultipleDropwizardJerseyClients_ThatAreAllBelowDefaultWarningThreshold() {
-                SortedMap<String, Gauge> gauges = (TreeMap) KiwiMaps.newTreeMap(
+                SortedMap<String, Gauge> gauges = KiwiMaps.newTreeMap(
                         leasedGaugeNameFor("some-client"), gaugeReturning(4),
                         maxGaugeNameFor("some-client"), gaugeReturning(10),
                         leasedGaugeNameFor("another-client"), gaugeReturning(2),
@@ -157,7 +157,7 @@ class HttpConnectionsHealthCheckTest {
             @SuppressWarnings({"unchecked", "rawtypes"})
             @Test
             void whenMultipleDropwizardJerseyClients_ThatOneIsAboveDefaultWarningThreshold() {
-                SortedMap<String, Gauge> gauges = (TreeMap) KiwiMaps.newTreeMap(
+                SortedMap<String, Gauge> gauges = KiwiMaps.newTreeMap(
                         leasedGaugeNameFor("some-client"), gaugeReturning(5),
                         maxGaugeNameFor("some-client"), gaugeReturning(10),
                         leasedGaugeNameFor("another-client"), gaugeReturning(2),
@@ -198,7 +198,7 @@ class HttpConnectionsHealthCheckTest {
             @SuppressWarnings({"unchecked", "rawtypes"})
             @Test
             void whenMultipleDropwizardJerseyClients_ThatAllAreAboveDefaultWarningThreshold() {
-                SortedMap<String, Gauge> gauges = (TreeMap) KiwiMaps.newTreeMap(
+                SortedMap<String, Gauge> gauges = KiwiMaps.newTreeMap(
                         leasedGaugeNameFor("some-client"), gaugeReturning(5),
                         maxGaugeNameFor("some-client"), gaugeReturning(10),
                         leasedGaugeNameFor("another-client"), gaugeReturning(9),

--- a/src/test/java/org/kiwiproject/dropwizard/util/health/keystore/KeystoreHealthResultsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/health/keystore/KeystoreHealthResultsTest.java
@@ -79,7 +79,7 @@ class KeystoreHealthResultsTest {
 
         @BeforeEach
         void setUp() {
-            var expiredCertl = BasicCertInfo.builder()
+            var expiredCert1 = BasicCertInfo.builder()
                     .subjectDN("cert-1")
                     .build();
             var expiredCert2 = BasicCertInfo.builder()
@@ -89,7 +89,7 @@ class KeystoreHealthResultsTest {
                     .path("/a/path/keystore.jks")
                     .expirationWarningThreshold(Duration.days(30))
                     .validCerts(List.of())
-                    .expiredCerts(List.of(expiredCertl, expiredCert2))
+                    .expiredCerts(List.of(expiredCert1, expiredCert2))
                     .expiringCerts(List.of())
                     .build();
         }


### PR DESCRIPTION
* Remove redundant 'throws' clause from health checks
* Rename local var in KeystoreHealthResultsTest that was supposed to
  end with a number one
* Remove redundant casts in HttpConnectionsHealthCheckTest