### PR TITLE
Change MongoHealthCheck to work with 4.x driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
             <!-- TODO: Remove version once update kiwi-bom with a mongodb-driver-sync.version property -->
-            <version>4.6.0</version>
+            <version>4.5.1</version>
             <scope>provided</scope>
         </dependency>
 
@@ -117,7 +117,7 @@
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-core</artifactId>
              <!-- TODO: Remove version once update kiwi-bom with a mongodb-driver-core.version property -->
-            <version>4.6.0</version>
+            <version>4.5.1</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,9 +98,26 @@
 
         <!-- Provided dependencies -->
 
+        <!--
+            NOTE:
+            The mongo driver to use is optional in Spring Data's POM.
+            You have to choose either the mongodb-driver-sync
+            or the mongodb-driver-reactivestreams as the driver.
+            The mongodb-driver-core is required by both of them.
+        -->
         <dependency>
             <groupId>org.mongodb</groupId>
-            <artifactId>mongo-java-driver</artifactId>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <!-- TODO: Remove version once update kiwi-bom with a mongodb-driver-sync.version property -->
+            <version>4.5.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-core</artifactId>
+             <!-- TODO: Remove version once update kiwi-bom with a mongodb-driver-core.version property -->
+            <version>4.5.1</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
             <!-- TODO: Remove version once update kiwi-bom with a mongodb-driver-sync.version property -->
-            <version>4.5.1</version>
+            <version>4.6.0</version>
             <scope>provided</scope>
         </dependency>
 
@@ -117,7 +117,7 @@
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-core</artifactId>
              <!-- TODO: Remove version once update kiwi-bom with a mongodb-driver-core.version property -->
-            <version>4.5.1</version>
+            <version>4.6.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kiwiproject</groupId>
         <artifactId>kiwi-parent</artifactId>
-        <version>1.8.2</version>
+        <version>2.0.0</version>
     </parent>
 
     <artifactId>dropwizard-service-utilities</artifactId>
@@ -31,7 +31,7 @@
         <!-- Versions for required dependencies -->
         <dropwizard-curator.version>1.1.5</dropwizard-curator.version>
         <kiwi.version>1.3.1</kiwi.version>
-        <kiwi-bom.version>0.7.3</kiwi-bom.version>
+        <kiwi-bom.version>0.9.0</kiwi-bom.version>
         <metrics-healthchecks-severity.version>1.0.5</metrics-healthchecks-severity.version>
         <service-discovery-client.version>1.1.4</service-discovery-client.version>
 
@@ -108,16 +108,12 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
-            <!-- TODO: Remove version once update kiwi-bom with a mongodb-driver-sync.version property -->
-            <version>4.5.1</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-core</artifactId>
-             <!-- TODO: Remove version once update kiwi-bom with a mongodb-driver-core.version property -->
-            <version>4.5.1</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/MongoHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/MongoHealthCheck.java
@@ -1,20 +1,29 @@
 package org.kiwiproject.dropwizard.util.health;
 
+import static org.kiwiproject.base.KiwiStrings.f;
 import static org.kiwiproject.metrics.health.HealthCheckResults.newResultBuilder;
 import static org.kiwiproject.metrics.health.HealthCheckResults.newUnhealthyResult;
 
+import java.util.Optional;
+
 import com.codahale.metrics.health.HealthCheck;
-import com.mongodb.DB;
+import com.mongodb.client.MongoDatabase;
+
 import lombok.extern.slf4j.Slf4j;
-import org.kiwiproject.metrics.health.HealthStatus;
+
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.Document;
 
 /**
- * Health check that attempts to pull dbStats from Mongo and report on the status.
- * <p>
- * Note this health check is currently using the deprecated {@link DB} class.
+ * Health check that attempts to issue a 'ping' command to a Mongo database.
+ *
+ * @see <a href="https://www.mongodb.com/docs/manual/reference/command/ping/">mongo ping command</a>
  */
 @Slf4j
 public class MongoHealthCheck extends HealthCheck {
+
+    private static final String NO_ERRMSG_VALUE = "[No errmsg value]";
 
     /**
      * A default name that can be used when registering this health check.
@@ -22,39 +31,89 @@ public class MongoHealthCheck extends HealthCheck {
     @SuppressWarnings("unused")
     public static final String DEFAULT_NAME = "Mongo";
 
-    private final DB db;
+    private final MongoDatabase database;
+    private final String dbName;
 
-    public MongoHealthCheck(DB db) {
-        this.db = db;
+    public MongoHealthCheck(MongoDatabase database) {
+        this.database = database;
+        this.dbName = database.getName();
     }
 
-
-    @SuppressWarnings({"deprecation", "ConstantConditions"})
+    /**
+     * Checks the health of a Mongo database by issuing a Mongo ping command.
+     * <p>
+     * Results always include the value of the "ok" property in the details. When the ping
+     * command fails (without throwing an exception), the details will also include the
+     * following from the result: "errmsg", "code", "codeName".
+     * <p>
+     * For example, if you send an unknown command to Mongo, the "code" will be 59 and
+     * the "codeName" will be the string "CommandNotFound". Note also that "code" and
+     * "codeName" can be null. For a list of MongoDB error codes, see
+     * <a href="https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.yml">here</a>.
+     */
     @Override
     protected Result check() {
-        var host = db.getMongo().getAddress().toString();
-        var dbName = db.getName();
-
         try {
-            var statsResult = db.getStats();
+            var pingCommand = new BsonDocument("ping", new BsonInt32(1));
+            var commandResult = database.runCommand(pingCommand);
+            LOG.trace("ping result: {}", commandResult);
 
-            var isHealthy = statsResult.ok();
-            var resultBuilder = newResultBuilder(isHealthy)
-                    .withDetail("storageSize", statsResult.get("storageSize"))
-                    .withDetail("dataSize", statsResult.get("dataSize"));
+            var okValue = commandResult.get("ok");
+            var isHealthy = ok(okValue);
+            var resultBuilder = newResultBuilder(isHealthy).withDetail("ok", okValue);
 
             if (isHealthy) {
-                return resultBuilder.withMessage("Mongo %s/%s is up", host, dbName).build();
+                return resultBuilder
+                    .withMessage("Successfully pinged Mongo database %s", dbName)
+                    .build();
             }
 
+            var errorMessage = errorMessage(commandResult).orElse(NO_ERRMSG_VALUE);
             return resultBuilder
-                    .withMessage("Failed to retrieve db stats %s/%s : %s",
-                            host, dbName, statsResult.getErrorMessage())
-                    .build();
+                .withMessage("Error pinging Mongo database %s : %s", dbName, errorMessage)
+                .withDetail("code", commandResult.get("code"))
+                .withDetail("codeName", commandResult.get("codeName"))
+                .build();
+
         } catch (Exception e) {
-            LOG.error("Unable to connect to Mongo: {}/{}", host, dbName, e);
-            return newUnhealthyResult(HealthStatus.CRITICAL, "Unable to connect to Mongo %s/%s: %s",
-                    host, dbName, e.getMessage());
+            var message = f("Error pinging Mongo database {} ({}: {})",
+                    dbName, e.getClass().getName(), e.getMessage());
+            LOG.error(message, e);
+            return newUnhealthyResult(e, message);
         }
+    }
+
+    /**
+     * @implNote The old Mongo 3.x driver had a CommandResult class that encapsulated the
+     * logic to check if commands were successful. It checked whether the 'ok' property in the
+     * result Document was a boolean, which is why this method is checking for both numeric
+     * and boolean values. The Mongo docs say that commands always return a 0 or 1 (integer)
+     * as the value of the 'ok' property, but in reality it returns 0.0 (double), so I decided
+     * to leave the original logic to be conservative. However, since the result should be a
+     * number, this performs the check for a number first, whereas the CommandResult checked
+     * for a boolean first.
+     */
+    private static boolean ok(Object okValue) {
+        if (okValue instanceof Number) {
+            return ((Number) okValue).intValue() == 1;
+        } else if (okValue instanceof Boolean) {
+            return (boolean) okValue;
+        } else {
+            LOG.warn("Received unexpected {} value in ping result for 'ok': {}",
+                    classNameOrNull(okValue),okValue);
+            return false;
+        }
+    }
+
+    private static String classNameOrNull(Object value) {
+        return Optional.ofNullable(value)
+                .map(Object::getClass)
+                .map(Class::getName)
+                .orElse(null);
+    }
+
+    private static Optional<String> errorMessage(Document commandResult) {
+        var errmsgValue = commandResult.get("errmsg");
+        return Optional.ofNullable(errmsgValue).map(Object::toString);
     }
 }

--- a/src/test/java/org/kiwiproject/dropwizard/util/health/MongoHealthCheckTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/health/MongoHealthCheckTest.java
@@ -1,93 +1,154 @@
 package org.kiwiproject.dropwizard.util.health;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kiwiproject.base.KiwiStrings.f;
 import static org.kiwiproject.test.assertj.dropwizard.metrics.HealthCheckResultAssertions.assertThatHealthCheck;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.mongodb.CommandResult;
-import com.mongodb.DB;
-import com.mongodb.Mongo;
-import com.mongodb.ServerAddress;
+import java.util.List;
+import java.util.Optional;
+
+import com.mongodb.client.MongoDatabase;
+
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.Document;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.kiwiproject.collect.KiwiMaps;
 import org.kiwiproject.metrics.health.HealthStatus;
+import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.OngoingStubbing;
 
-@SuppressWarnings("deprecation")
 @DisplayName("MongoHealthCheck")
 class MongoHealthCheckTest {
 
-    private static final String DB_NAME = "someName";
-    private static final String SERVER_ADDRESS = "localhost:27017";
+    private static final String DB_NAME = "testDatabase";
+    private static final String OK_PROPERTY = "ok";
+    private static final String ERROR_MESSAGE_PROPERTY = "errmsg";
+    private static final String CODE_PROPERTY = "code";
+    private static final String CODE_NAME_PROPERTY = "codeName";
 
     @Nested
     class IsHealthy {
 
-        @Test
-        void whenGetStatsReturnsSuccessfully() {
-            var mockDb = createMockedMongoDb(true);
-            var healthCheck = new MongoHealthCheck(mockDb);
+        @ParameterizedTest
+        @MethodSource("org.kiwiproject.dropwizard.util.health.MongoHealthCheckTest#successfulCommandResults")
+        void whenPingSucceeds(Document commandResult) {
+            var database = setupMockMongoDatabase();
+            whenReceivesRunCommand(database).thenReturn(commandResult);
+
+            var healthCheck = new MongoHealthCheck(database);
 
             assertThatHealthCheck(healthCheck)
                     .isHealthy()
-                    .hasMessage("Mongo " + SERVER_ADDRESS + "/" + DB_NAME + " is up")
-                    .hasDetailsContainingKeys("storageSize", "dataSize");
+                    .hasMessage(f("Successfully pinged Mongo database {}", DB_NAME))
+                    .hasDetail("severity", HealthStatus.OK.name())
+                    .hasDetail(OK_PROPERTY, commandResult.get(OK_PROPERTY))
+                    .doesNotHaveDetailsContainingKeys(ERROR_MESSAGE_PROPERTY, CODE_PROPERTY, CODE_NAME_PROPERTY);
+
+            verifyRunPingCommand(database);
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Nested
     class IsUnhealthy {
 
         @Test
         void whenExceptionIsThrown() {
-            var mockDb = setupMockDB();
-            when(mockDb.getStats()).thenThrow(new RuntimeException("oops"));
+            var database = setupMockMongoDatabase();
+            var message = "oops";
+            whenReceivesRunCommand(database).thenThrow(new RuntimeException(message));
 
-            var healthCheck = new MongoHealthCheck(mockDb);
+            var healthCheck = new MongoHealthCheck(database);
 
             assertThatHealthCheck(healthCheck)
                     .isUnhealthy()
+                    .hasMessage(f("Error pinging Mongo database {} ({}: {})",
+                            DB_NAME, RuntimeException.class.getName(), message))
                     .hasDetail("severity", HealthStatus.CRITICAL.name())
-                    .hasMessageStartingWith("Unable to connect to Mongo " + SERVER_ADDRESS + "/" + DB_NAME + ": oops");
+                    .doesNotHaveDetailsContainingKeys(OK_PROPERTY, ERROR_MESSAGE_PROPERTY, CODE_PROPERTY, CODE_NAME_PROPERTY);
 
+            verifyRunPingCommand(database);
         }
 
-        @Test
-        void whenGetStatsFails() {
-            var mockDb = createMockedMongoDb(false);
-            var healthCheck = new MongoHealthCheck(mockDb);
+        @ParameterizedTest
+        @MethodSource("org.kiwiproject.dropwizard.util.health.MongoHealthCheckTest#failedCommandResults")
+        void whenCommandFails(Document commandResult) {
+            var database = setupMockMongoDatabase();
+            whenReceivesRunCommand(database).thenReturn(commandResult);
+
+            var healthCheck = new MongoHealthCheck(database);
+
+            var expectedErrmsgValue = Optional.ofNullable(commandResult.get(ERROR_MESSAGE_PROPERTY))
+                    .orElse("[No errmsg value]");
 
             assertThatHealthCheck(healthCheck)
                     .isUnhealthy()
-                    .hasMessageStartingWith("Failed to retrieve db stats " + SERVER_ADDRESS + "/" + DB_NAME + " : ");
+                    .hasMessage(f("Error pinging Mongo database {} : {}", DB_NAME, expectedErrmsgValue))
+                    .hasDetail("severity", HealthStatus.WARN.name())
+                    .hasDetail(OK_PROPERTY, commandResult.get(OK_PROPERTY))
+                    .hasDetail(CODE_PROPERTY, commandResult.get(CODE_PROPERTY))
+                    .hasDetail(CODE_NAME_PROPERTY, commandResult.get(CODE_NAME_PROPERTY));
+
+            verifyRunPingCommand(database);
         }
     }
 
-    private static DB createMockedMongoDb(boolean getStatsSuccessful) {
-        var mockDb = setupMockDB();
-        var mockedResult = mockedCommandResult(getStatsSuccessful);
-
-        when(mockDb.getStats()).thenReturn(mockedResult);
-        return mockDb;
+    private static MongoDatabase setupMockMongoDatabase() {
+        var mockDatabase = mock(MongoDatabase.class);
+        when(mockDatabase.getName()).thenReturn(DB_NAME);
+        return mockDatabase;
     }
 
-    private static DB setupMockDB() {
-        var mockDb = mock(DB.class);
-        var mockMongo = mock(Mongo.class);
-        var mockServerAddress = mock(ServerAddress.class);
-
-        when(mockDb.getMongo()).thenReturn(mockMongo);
-        when(mockMongo.getAddress()).thenReturn(mockServerAddress);
-        when(mockServerAddress.toString()).thenReturn(MongoHealthCheckTest.SERVER_ADDRESS);
-        when(mockDb.getName()).thenReturn(MongoHealthCheckTest.DB_NAME);
-
-        return mockDb;
+    private OngoingStubbing<Document> whenReceivesRunCommand(MongoDatabase database) {
+        return when(database.runCommand(any(BsonDocument.class)));
     }
 
-    private static CommandResult mockedCommandResult(boolean ok) {
-        var result = mock(CommandResult.class);
-        when(result.ok()).thenReturn(ok);
-        return result;
+    private static List<Document> successfulCommandResults() {
+        var ok = OK_PROPERTY;
+        return List.of(
+            new Document(ok, true),
+            new Document(ok, 1),
+            new Document(ok, 1L),
+            new Document(ok, 1.0F),
+            new Document(ok, 1.0)
+        );
+    }
+
+    private static List<Document> failedCommandResults() {
+        return List.of(
+            newFailedDocument("no such command 'crash'", 59, "CommandNotFound"),
+            newFailedDocument("scale has to be a number > 0", null, null),
+            newFailedDocument("an error occurred", 42, "The Code", false),
+            newFailedDocument("unknown error", null, null, null),
+            newFailedDocument(null, null, null, "true")
+        );
+    }
+
+    private static Document newFailedDocument(String errmsg, Integer code, String codeName) {
+        return newFailedDocument(errmsg, code, codeName, 0.0);
+    }
+
+    private static Document newFailedDocument(String errmsg, Integer code, String codeName, Object okValue) {
+        return new Document(KiwiMaps.newHashMap(
+            OK_PROPERTY, okValue,
+            ERROR_MESSAGE_PROPERTY, errmsg,
+            CODE_PROPERTY, code,
+            CODE_NAME_PROPERTY, codeName
+        ));
+    }
+
+    private void verifyRunPingCommand(MongoDatabase database) {
+        var inputCaptor = ArgumentCaptor.forClass(BsonDocument.class);
+        verify(database).runCommand(inputCaptor.capture());
+        var bsonInputDoc = inputCaptor.getValue();
+        assertThat(bsonInputDoc).containsEntry("ping", new BsonInt32(1));
     }
 }

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{5} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.kiwiproject.dropwizard.util" level="TRACE"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
This is a breaking API change, since the DB class no longer exists
in the Mongo 4.x driver. It was  replaced by MongoDatabase. Thus,
the constructor had to change. The MongoDatabase also does not
contain as much information, e.g. you cannot obtain the host and port
information as you could with DB, which provided a getMongo() method
from which you could obtain a ServerAddress in order to find the host
and port. We decided that information does not add enough value to
require callers to include a host and port, though we could re-evauate
that decision later.

This commit, therefore, changes MongoHealthCheck to work with the
4.x driver. The health check has been using the "dbStats" command which
"returns storage statistics for a given database". The problem with this
is that, from the docs, "The time required to run the command depends on
the total size of the database. Because the command must touch all data
files, the command may take several seconds to run." Health checks
should definitely not run any commands that could cause performance
problems or take seconds to execute.

This commit changes the MongoHealthCheck to use the ping command, which
"is a no-op used to test whether a server is responding to commands",
and it "will return immediately even if the server is write-locked". This
is much better for a health check, and should obviously be much faster and
less resource intensive on Mongo.

Closes #233