### PR TITLE
StandardLifecycles improvements

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/lifecycle/ProcessIdLoggingServerLifecycleListener.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/lifecycle/ProcessIdLoggingServerLifecycleListener.java
@@ -10,6 +10,10 @@ import org.eclipse.jetty.server.Server;
 class ProcessIdLoggingServerLifecycleListener implements ServerLifecycleListener {
     private final Long processId;
 
+    ProcessIdLoggingServerLifecycleListener(long processId) {
+        this.processId = processId;
+    }
+
     ProcessIdLoggingServerLifecycleListener(Long processId) {
         this.processId = processId;
     }

--- a/src/main/java/org/kiwiproject/dropwizard/util/lifecycle/StandardLifecycles.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/lifecycle/StandardLifecycles.java
@@ -13,6 +13,7 @@ import org.kiwiproject.registry.management.dropwizard.RegistrationLifecycleListe
 import org.kiwiproject.registry.server.RegistryService;
 
 import java.time.Instant;
+import java.util.OptionalLong;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.regex.Pattern;
 
@@ -71,6 +72,35 @@ public class StandardLifecycles {
      */
     public static void addServerConnectorLoggingLifecycleListener(Environment environment) {
         environment.lifecycle().addServerLifecycleListener(new ConnectorLoggingServerLifecycleListener());
+    }
+
+    /**
+     * Adds a lifecycle listener that logs the current process id on startup.
+     *
+     * @param processId   the process id or an empty optional if unable to find it
+     * @param environment the Dropwizard environment
+     * @implNote Yes, the generally accepted wisdom is that Optional arguments are "bad". However, in this
+     * situation we make an exception to that "rule" to support the case when a {@link Process#pid()} does not
+     * support getting the pid. Our kiwi library has a {@link org.kiwiproject.base.KiwiEnvironment#tryGetCurrentPid()}
+     * which returns {@link OptionalLong}, and this method makes it convenient to take the result of that method
+     * and supply it directly to this method without converting it.
+     */
+    public static void addProcessIdLoggingLifecycleListener(OptionalLong processId, Environment environment) {
+        if (processId.isPresent()) {
+            addProcessIdLoggingLifecycleListener(processId.getAsLong(), environment);
+        } else {
+            addProcessIdLoggingLifecycleListener((Long) null, environment);
+        }
+    }
+
+    /**
+     * Adds a lifecycle listener that logs the current process id on startup.
+     *
+     * @param processId   the process id
+     * @param environment the Dropwizard environment
+     */
+    public static void addProcessIdLoggingLifecycleListener(long processId, Environment environment) {
+        environment.lifecycle().addServerLifecycleListener(new ProcessIdLoggingServerLifecycleListener(processId));
     }
 
     /**

--- a/src/test/java/org/kiwiproject/dropwizard/util/lifecycle/ProcessIdLoggingServerLifecycleListenerTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/lifecycle/ProcessIdLoggingServerLifecycleListenerTest.java
@@ -10,8 +10,16 @@ import org.junit.jupiter.api.Test;
 class ProcessIdLoggingServerLifecycleListenerTest {
 
     @Test
-    void shouldNotThrowException_WhenPidProvided() {
+    void shouldNotThrowException_WhenPidProvided_AsPrimitiveLong() {
         var listener = new ProcessIdLoggingServerLifecycleListener(10_000L);
+        var server = new Server(8080);
+
+        assertThatCode(() -> listener.serverStarted(server)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldNotThrowException_WhenPidProvided_AsWrapperLong() {
+        var listener = new ProcessIdLoggingServerLifecycleListener(Long.valueOf(20_000L));
         var server = new Server(8080);
 
         assertThatCode(() -> listener.serverStarted(server)).doesNotThrowAnyException();

--- a/src/test/java/org/kiwiproject/dropwizard/util/lifecycle/StandardLifecyclesTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/lifecycle/StandardLifecyclesTest.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.when;
 import com.codahale.metrics.NoopMetricRegistry;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.setup.Environment;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,7 @@ import org.kiwiproject.registry.management.dropwizard.RegistrationLifecycleListe
 import org.kiwiproject.registry.server.RegistryService;
 import org.kiwiproject.test.dropwizard.mockito.DropwizardMockitoMocks;
 
+import java.util.OptionalLong;
 import java.util.concurrent.ScheduledExecutorService;
 
 @DisplayName("StandardLifecycles")
@@ -73,16 +76,52 @@ class StandardLifecyclesTest {
     @Nested
     class AddProcessIdLoggingLifecycleListener {
 
-        @Test
-        void shouldAddProcessIdLoggingLifecycleListener() {
-            var environment = DropwizardMockitoMocks.mockEnvironment();
+        private Environment environment;
 
+        @BeforeEach
+        void setUp() {
+            environment = DropwizardMockitoMocks.mockEnvironment();
+        }
+
+        @Test
+        void shouldAddProcessIdLoggingLifecycleListener_FromPrimitiveLong() {
             StandardLifecycles.addProcessIdLoggingLifecycleListener(10_000L, environment);
 
+            verifyListenerAdded();
+        }
+
+        @Test
+        void shouldAddProcessIdLoggingLifecycleListener_FromWrapperLong() {
+            StandardLifecycles.addProcessIdLoggingLifecycleListener(Long.valueOf(20_000L), environment);
+
+            verifyListenerAdded();
+        }
+
+        @Test
+        void shouldAddProcessIdLoggingLifecycleListener_FromWrapperLong_EvenWhenNull() {
+            StandardLifecycles.addProcessIdLoggingLifecycleListener((Long) null, environment);
+
+            verifyListenerAdded();
+        }
+
+        @Test
+        void shouldAddProcessIdLoggingLifecycleListener_FromOptionalLong() {
+            StandardLifecycles.addProcessIdLoggingLifecycleListener(OptionalLong.of(30_000L), environment);
+
+            verifyListenerAdded();
+        }
+
+        @Test
+        void shouldAddProcessIdLoggingLifecycleListener_FromOptionalLong_EvenWhenEmpty() {
+            StandardLifecycles.addProcessIdLoggingLifecycleListener(OptionalLong.empty(), environment);
+
+            verifyListenerAdded();
+        }
+
+        private void verifyListenerAdded() {
             verify(environment.lifecycle())
                     .addServerLifecycleListener(any(ProcessIdLoggingServerLifecycleListener.class));
         }
-
     }
 
     @Nested


### PR DESCRIPTION
* Overload addProcessIdLoggingLifecycleListener in StandardLifecycles to
  accept a long as well as an OptionalLong, in addition to the existing
  Long, for the process ID
* Add constructor in ProcessIdLoggingServerLifecycleListener that
  accepts long

Closes #247
Closes #248