### PR TITLE
Removed unused code

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/health/keystore/KeystoreHealthResults.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/keystore/KeystoreHealthResults.java
@@ -15,7 +15,6 @@ import org.kiwiproject.base.KiwiEnvironment;
 import org.kiwiproject.dropwizard.util.KiwiDropwizardDurations;
 import org.kiwiproject.metrics.health.HealthStatus;
 
-import java.time.ZoneId;
 import java.time.chrono.ChronoZonedDateTime;
 import java.util.List;
 
@@ -23,7 +22,6 @@ import java.util.List;
 @Builder
 class KeystoreHealthResults {
 
-    private static final ZoneId UTC_ZONE_ID = ZoneId.of("UTC");
     private static final KiwiEnvironment DEFAULT_KIWI_ENVIRONMENT = new DefaultEnvironment();
 
     @NonNull

--- a/src/main/java/org/kiwiproject/dropwizard/util/resource/ConfigResource.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/resource/ConfigResource.java
@@ -6,7 +6,6 @@ import static org.kiwiproject.json.KiwiJacksonSerializers.buildPropertyMaskingSa
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.Configuration;
-import lombok.extern.slf4j.Slf4j;
 import org.kiwiproject.json.JsonHelper;
 
 import javax.ws.rs.GET;
@@ -20,7 +19,6 @@ import java.util.List;
  * <p>
  * A list of regex patterns can be given in order to mask secrets in the configuration.
  */
-@Slf4j
 @Path("app/config")
 public class ConfigResource {
 

--- a/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobsTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.when;
 import io.dropwizard.lifecycle.setup.ScheduledExecutorServiceBuilder;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Duration;
-import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.awaitility.Durations;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,7 +34,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 @DisplayName("MonitoredJobs")
 @ExtendWith(SoftAssertionsExtension.class)
-@Slf4j
 class MonitoredJobsTest {
 
     private Environment env;


### PR DESCRIPTION
* Remove Slf4j annotations from ConfigResource and MonitoredJobsTest
  since neither actually uses the Logger that it provides
* Remove the unused ZoneId static final field from KeystoreHealthResults