### PR TITLE
Sonar: fix regular expression in ServerLoadFetcher

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/metrics/ServerLoadFetcher.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/metrics/ServerLoadFetcher.java
@@ -25,7 +25,8 @@ public class ServerLoadFetcher {
      */
     public static final String NO_VALUE = "0.00, 0.00, 0.00";
 
-    private static final Pattern LOAD_AVERAGE_PATTERN = Pattern.compile("load average[s]?: (.*)");
+    private static final Pattern LOAD_AVERAGE_PATTERN =
+            Pattern.compile("load averages?: (.*)", Pattern.CASE_INSENSITIVE);
 
     private final ProcessHelper processes;
 
@@ -47,7 +48,9 @@ public class ServerLoadFetcher {
      * <p>
      * {@code 18:29:28 up 34 days, 18:25, 1 user, load averages: 0.88 0.98 1.03}
      *
-     * @return an {@link Optional} with the load average string or {@link Optional#empty()} if not found
+     * @return an {@link Optional} with the load average string; otherwise an {@link Optional#empty()} if
+     * the load average was not found or if any error occurred
+     * @implNote the pattern match is case-insensitive against the output of the uptime command
      */
     public Optional<String> get() {
         var process = processes.launch("uptime");


### PR DESCRIPTION
* Fix issue java:S6397 (Character classes in regular expressions should
  not contain only one character) in the ServerLoadFetcher load average
  Pattern
* Make ServerLoadFetcher#LOAD_AVERAGE_PATTERN case-insensitive
* Update the javadocs on ServerLoadFetcher#get for the return value
  and add an implementation note about the match being case-insensitive
* Refactor ServerLoadFetcherTest in the nested class format with
  "should" semantics for test names
* Remove character classes around commas in ServerLoadFetcherTest in the
  test using an actual OS process
* Change test ServerLoadFetcherTest to be a parameterized test to verify
  both Linux and macOS formats, as well as case-insensitive behavior