### PR TITLE
Fix javadoc of StandardJacksonConfigurations

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/jackson/StandardJacksonConfigurations.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/jackson/StandardJacksonConfigurations.java
@@ -50,9 +50,9 @@ public class StandardJacksonConfigurations {
      * method will also optionally register a Health Check to mark the service unhealthy if there are deserialization
      * issues.
      * <p>
-     * This method only configures the handler if {@link JacksonConfig#isIgnoreButWarnForUnknownJsonProperties()} is
+     * This method only configures the handler if {@code JacksonConfig#isIgnoreButWarnForUnknownJsonProperties()} is
      * true. If the aforementioned property is true, this method adds the health check if
-     * {@link JacksonConfig#isRegisterHealthCheckForUnknownJsonProperties()} is true.
+     * {@code JacksonConfig#isRegisterHealthCheckForUnknownJsonProperties()} is true.
      *
      * @param config       a config model containing various options for configuring Jackson
      * @param mapper       the {@link ObjectMapper} to attach the handler to
@@ -76,7 +76,7 @@ public class StandardJacksonConfigurations {
      * Optionally configures the {@link ObjectMapper} to convert all Timestamps into milliseconds.
      * <p>
      * This method only configures the mapper's timestamp handling if
-     * {@link JacksonConfig#isReadAndWriteDateTimestampsAsMillis()} is true.
+     * {@code JacksonConfig#isReadAndWriteDateTimestampsAsMillis()} is true.
      *
      * @param config a config model containing various options for configuring Jackson
      * @param mapper the {@link ObjectMapper} to configure
@@ -92,7 +92,7 @@ public class StandardJacksonConfigurations {
      * Optionally configures the {@link ObjectMapper} to serialize {@link JAXBElement} elements
      * using {@link JaxbElementSerializer}. Converts nil {@link JAXBElement} into JSON null.
      * <p>
-     * This method only configures the mapper if {@link JacksonConfig#isWriteNilJaxbElementsAsNull()} is true.
+     * This method only configures the mapper if {@code JacksonConfig#isWriteNilJaxbElementsAsNull()} is true.
      *
      * @param config a config model containing various options for configuring Jackson
      * @param mapper the {@link ObjectMapper} to configure


### PR DESCRIPTION
Since the getter methods in JacksonConfig are generated by Lombok,
javadoc fails. So, changed from link to just code, which is not awesome,
but it does let javadoc complete successfully.

Closes #284