### PR TITLE
Add constructors to ConfigResource for ObjectMapper customization

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/resource/ConfigResource.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/resource/ConfigResource.java
@@ -5,6 +5,7 @@ import static org.kiwiproject.json.KiwiJacksonSerializers.buildPropertyMaskingSa
 
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import io.dropwizard.Configuration;
 import org.kiwiproject.json.JsonHelper;
@@ -14,25 +15,75 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * JAX-RS resource that enables the retrieval of the current runtime configuration of the service.
  * <p>
- * A list of regex patterns can be given in order to mask secrets in the configuration.
+ * A list of regex patterns can be provided to the "default" constructor in order to mask secrets in the configuration.
  */
 @Path("app/config")
 public class ConfigResource {
 
-    // Intentionally creating a separate JsonHelper to allow customizations
     private final JsonHelper jsonHelper;
     private final Configuration config;
 
+    /**
+     * This is the "default" constructor and is the recommended way to create instances. If you
+     * have very specific requirements or needs for serialization, you can use one of the constructors
+     * that accepts an {@link ObjectMapper} or a {@link JsonHelper}.
+     * <p>
+     * The created instance contains an {@link ObjectMapper} that disables
+     * {@link SerializationFeature#FAIL_ON_EMPTY_BEANS} and which masks properties that contain any of the
+     * provided regular expressions in {@code hiddenRegex}.
+     *
+     * @param config      the Dropwizard {@link Configuration}
+     * @param hiddenRegex list of regex patterns for masking secrets in the configuration
+     */
     public ConfigResource(Configuration config, List<String> hiddenRegex) {
         this.config = config;
         this.jsonHelper = JsonHelper.newDropwizardJsonHelper();
 
         jsonHelper.getObjectMapper().registerModule(buildPropertyMaskingSafeSerializerModule(hiddenRegex));
         jsonHelper.getObjectMapper().disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+    }
+
+    /**
+     * Create an instance using the given {@link ObjectMapper} "as-is". No customizations are done, so
+     * make sure it handles everything you need such as masking passwords or secrets.
+     *
+     * @param config       the Dropwizard {@link Configuration}
+     * @param objectMapper the ObjectMapper to use for JSON serialization
+     */
+    public ConfigResource(Configuration config, ObjectMapper objectMapper) {
+        this(config, new JsonHelper(objectMapper));
+    }
+
+    /**
+     * Create an instance using the given {@link JsonHelper} "as-is". No customizations are done, so make
+     * sure it handles everything you need such as masking passwords or secrets.
+     *
+     * @param config     the Dropwizard {@link Configuration}
+     * @param jsonHelper the JsonHelper to use for JSON serialization
+     */
+    public ConfigResource(Configuration config, JsonHelper jsonHelper) {
+        this.config = config;
+        this.jsonHelper = jsonHelper;
+    }
+
+    /**
+     * Create an instance and customize how JSON serialization is performed using the {@link Consumer}.
+     * Only the customizations applied in the Consumer are applied to the {@link ObjectMapper}, so make
+     * sure to handle everything you need such as masking passwords or secrets.
+     *
+     * @param config                 the Dropwizard {@link Configuration}
+     * @param objectMapperCustomizer a Consumer that provides an ObjectMapper for customization
+     */
+    public ConfigResource(Configuration config, Consumer<ObjectMapper> objectMapperCustomizer) {
+        this.config = config;
+        this.jsonHelper = JsonHelper.newDropwizardJsonHelper();
+
+        objectMapperCustomizer.accept(jsonHelper.getObjectMapper());
     }
 
     @GET

--- a/src/test/java/org/kiwiproject/dropwizard/util/resource/ConfigResourceTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/resource/ConfigResourceTest.java
@@ -3,11 +3,14 @@ package org.kiwiproject.dropwizard.util.resource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.kiwiproject.jaxrs.KiwiGenericTypes.MAP_OF_STRING_TO_OBJECT_GENERIC_TYPE;
+import static org.kiwiproject.json.KiwiJacksonSerializers.buildPropertyMaskingSafeSerializerModule;
 import static org.kiwiproject.test.constants.KiwiTestConstants.JSON_HELPER;
 
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
+import io.dropwizard.jackson.Jackson;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
@@ -20,6 +23,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junitpioneer.jupiter.Issue;
+import org.kiwiproject.json.JsonHelper;
 import org.kiwiproject.json.RuntimeJsonException;
 import org.kiwiproject.test.assertj.KiwiAssertJ;
 import org.kiwiproject.test.junit.jupiter.ClearBoxTest;
@@ -80,11 +84,12 @@ class ConfigResourceTest {
         }
     }
 
-    private static final TestConfig CONFIG = new TestConfig("foo", "secret",
-            new CacheConfig(Duration.ofSeconds(10), Duration.ofSeconds(5), Duration.ofSeconds(25),
-                    (logger, message, error) -> {
-                        // do nothing...doesn't matter for this test
-                    }));
+    private static final CacheConfig CACHE_CONFIG = new CacheConfig(
+            Duration.ofSeconds(10), Duration.ofSeconds(5), Duration.ofSeconds(25),
+            (logger, message, error) -> {
+                // do nothing...doesn't matter for this test
+            });
+    private static final TestConfig CONFIG = new TestConfig("foo", "secret", CACHE_CONFIG);
     private static final DropwizardAppExtension<TestConfig> APP = new DropwizardAppExtension<>(TestApp.class, CONFIG);
 
     @Test
@@ -120,6 +125,75 @@ class ConfigResourceTest {
         assertThat(cacheConfigMap)
                 .describedAs("empty non-serializable bean should be an empty map")
                 .containsEntry("errorLogConsumer", Map.of());
+    }
+
+    /**
+     * @implNote This is a pure unit test, since it calls the resource class directly.
+     */
+    @Test
+    void shouldAllowCreatingWithCustomObjectMapper() {
+        var testConfig = new TestConfig("bar", "notVerySecret", CACHE_CONFIG);
+
+        var objectMapper = Jackson.newObjectMapper();
+        objectMapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+        var resource = new ConfigResource(testConfig, objectMapper);
+
+        var response = resource.getCurrentConfiguration();
+
+        var json = (String) response.getEntity();
+        var configData = JSON_HELPER.toMap(json);
+
+        assertThat(configData)
+                .containsEntry("someNeededProperty", "bar")
+                .containsEntry("someHiddenPassword", "notVerySecret")
+                .containsKey("cacheConfig");
+    }
+
+    /**
+     * @implNote This is a pure unit test, since it calls the resource class directly.
+     */
+    @Test
+    void shouldAllowCreatingWithCustomJsonHelper() {
+        var testConfig = new TestConfig("bar", "notVerySecret", CACHE_CONFIG);
+
+        var jsonHelper = JsonHelper.newDropwizardJsonHelper();
+        jsonHelper.getObjectMapper().disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+        var resource = new ConfigResource(testConfig, jsonHelper);
+
+        var response = resource.getCurrentConfiguration();
+
+        var json = (String) response.getEntity();
+        var configData = JSON_HELPER.toMap(json);
+
+        assertThat(configData)
+                .containsEntry("someNeededProperty", "bar")
+                .containsEntry("someHiddenPassword", "notVerySecret")
+                .containsKey("cacheConfig");
+    }
+
+    /**
+     * @implNote This is a pure unit test, since it calls the resource class directly.
+     */
+    @Test
+    void shouldAllowCreatingWithObjectMapperConsumer() {
+        var testConfig = new TestConfig("bar", "YouCantSeeMe", CACHE_CONFIG);
+
+        var resource = new ConfigResource(testConfig, objectMapper -> {
+            objectMapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+
+            var hiddenRegex = List.of(".*password", ".*secret", ".*credential");
+            objectMapper.registerModule(buildPropertyMaskingSafeSerializerModule(hiddenRegex));
+        });
+
+        var response = resource.getCurrentConfiguration();
+
+        var json = (String) response.getEntity();
+        var configData = JSON_HELPER.toMap(json);
+
+        assertThat(configData)
+                .containsEntry("someNeededProperty", "bar")
+                .containsEntry("someHiddenPassword", "********")
+                .containsKey("cacheConfig");
     }
 
     private static Map<String, Object> getAppConfig() {


### PR DESCRIPTION
* Add three constructors to ConfigResource to allow callers to provide a custom ObjectMapper, JsonHelper, or to customize an internally-created ObjectMapper
* Note that the tests are unit tests; without creating separate DropwizardAppExtensions there is not a way to change the resource for each test. Since there are already integration tests, testing the resource class directly seems like an acceptable tradeoff.

Closes #289