### PR TITLE
Fix deprecated code usage

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/health/keystore/KeystoreHealthResults.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/keystore/KeystoreHealthResults.java
@@ -12,7 +12,6 @@ import lombok.Getter;
 import lombok.NonNull;
 import org.kiwiproject.base.DefaultEnvironment;
 import org.kiwiproject.base.KiwiEnvironment;
-import org.kiwiproject.dropwizard.util.KiwiDropwizardDurations;
 import org.kiwiproject.metrics.health.HealthStatus;
 
 import java.time.chrono.ChronoZonedDateTime;
@@ -79,7 +78,7 @@ class KeystoreHealthResults {
 
         var nowAtUTC = kiwiEnvironment.currentZonedDateTimeUTC();
         var durationUntilExpiration = java.time.Duration.between(nowAtUTC, earliestExpirationDate);
-        var fullWarningThreshold = KiwiDropwizardDurations.fromDropwizardDuration(expirationWarningThreshold);
+        var fullWarningThreshold = expirationWarningThreshold.toJavaDuration();
 
         var halfWarningThreshold = fullWarningThreshold.dividedBy(2);
         if (durationUntilExpiration.compareTo(halfWarningThreshold) >= 0) {

--- a/src/main/java/org/kiwiproject/dropwizard/util/job/MonitoredJobs.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/job/MonitoredJobs.java
@@ -12,7 +12,6 @@ import io.dropwizard.setup.Environment;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.kiwiproject.base.KiwiEnvironment;
-import org.kiwiproject.dropwizard.util.KiwiDropwizardDurations;
 import org.kiwiproject.dropwizard.util.config.JobSchedule;
 import org.kiwiproject.dropwizard.util.health.MonitoredJobHealthCheck;
 
@@ -216,7 +215,7 @@ public class MonitoredJobs {
         }
 
         public Builder timeout(io.dropwizard.util.Duration timeout) {
-            return timeout(KiwiDropwizardDurations.fromDropwizardDuration(timeout));
+            return timeout(timeout.toJavaDuration());
         }
 
         public Builder timeout(Duration timeout) {

--- a/src/test/java/org/kiwiproject/dropwizard/util/resource/ConfigResourceTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/resource/ConfigResourceTest.java
@@ -114,6 +114,7 @@ class ConfigResourceTest {
 
     @Test
     @Issue("290")
+    @SuppressWarnings("unchecked")
     void shouldHandleNonSerializableBeans() {
         var configData = getAppConfig();
 
@@ -121,7 +122,6 @@ class ConfigResourceTest {
         var cacheConfig = configData.get("cacheConfig");
         var cacheConfigMap = KiwiAssertJ.assertIsTypeOrSubtype(cacheConfig, Map.class);
 
-        // noinspection unchecked
         assertThat(cacheConfigMap)
                 .describedAs("empty non-serializable bean should be an empty map")
                 .containsEntry("errorLogConsumer", Map.of());


### PR DESCRIPTION
* Replace usages of KiwiDropwizardDurations.fromDropwizardDuration with the toJavaDuration method on Dropwizard's Duration class
* Change from comment suppressing an unchecked conversion to annotation