### PR TITLE
Update parent POM and BOM for JDK 17 and major library updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ '11', '17', '20' ]
+        java_version: [ '17', '20' ]
     steps:
       # Check out the project
       - uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
       # Cache all the things
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
@@ -54,16 +54,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V compile
 
-      # Run tests when Java version > 11 (Sonar runs tests and analysis on JDK 11)
+      # Run tests when Java version > 17 (Sonar runs tests and analysis on JDK 17)
       - name: Run tests
-        if: ${{ matrix.java_version != '11' }}
+        if: ${{ matrix.java_version != '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V verify
 
-      # Run Sonar Analysis (on Java version 11 only)
+      # Run Sonar Analysis (on Java version 17 only)
       - name: Analyze with SonarCloud
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Set up Java 17
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 17
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>org.kiwiproject</groupId>
         <artifactId>kiwi-parent</artifactId>
-        <version>2.0.20</version>
+        <version>3.0.1</version>
     </parent>
 
     <artifactId>dropwizard-service-utilities</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -29,17 +29,17 @@
 
     <properties>
         <!-- Versions for required dependencies -->
-        <dropwizard-curator.version>1.1.13</dropwizard-curator.version>
-        <kiwi.version>2.7.0</kiwi.version>
-        <kiwi-bom.version>1.1.1</kiwi-bom.version>
-        <metrics-healthchecks-severity.version>1.0.13</metrics-healthchecks-severity.version>
-        <service-discovery-client.version>1.2.1</service-discovery-client.version>
+        <dropwizard-curator.version>2.0.0</dropwizard-curator.version>
+        <kiwi.version>3.0.0</kiwi.version>
+        <kiwi-bom.version>2.0.0</kiwi-bom.version>
+        <metrics-healthchecks-severity.version>2.0.0</metrics-healthchecks-severity.version>
+        <service-discovery-client.version>2.0.0</service-discovery-client.version>
 
         <!-- Versions for provided dependencies -->
-        <registry-aware-jersey-client>1.1.13</registry-aware-jersey-client>
+        <registry-aware-jersey-client>2.0.0</registry-aware-jersey-client>
 
         <!-- Versions for test dependencies -->
-        <kiwi-test.version>2.4.0</kiwi-test.version>
+        <kiwi-test.version>3.0.0</kiwi-test.version>
 
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_dropwizard-service-utilities</sonar.projectKey>
@@ -161,7 +161,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-core</artifactId>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/org/kiwiproject/dropwizard/util/admin/AdminConfigurator.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/admin/AdminConfigurator.java
@@ -4,8 +4,8 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
 
 import com.codahale.metrics.MetricRegistry;
-import io.dropwizard.Configuration;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.Configuration;
+import io.dropwizard.core.setup.Environment;
 import org.kiwiproject.config.TlsContextConfiguration;
 import org.kiwiproject.dropwizard.util.config.HttpHealthCheckConfig;
 import org.kiwiproject.dropwizard.util.config.KeystoreConfig;

--- a/src/main/java/org/kiwiproject/dropwizard/util/config/JobSchedule.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/config/JobSchedule.java
@@ -3,14 +3,13 @@ package org.kiwiproject.dropwizard.util.config;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
 import io.dropwizard.util.Duration;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import javax.validation.constraints.NotNull;
 
 /**
  * Config object that defines a schedule for background jobs.

--- a/src/main/java/org/kiwiproject/dropwizard/util/config/KeystoreConfig.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/config/KeystoreConfig.java
@@ -1,6 +1,8 @@
 package org.kiwiproject.dropwizard.util.config;
 
 import io.dropwizard.util.Duration;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -8,9 +10,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.kiwiproject.security.KeyStoreType;
-
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 
 /**
  * Configuration for keystore health checks.

--- a/src/main/java/org/kiwiproject/dropwizard/util/environment/StandardEnvironmentConfigurations.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/environment/StandardEnvironmentConfigurations.java
@@ -1,6 +1,6 @@
 package org.kiwiproject.dropwizard.util.environment;
 
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
 import lombok.experimental.UtilityClass;
 import org.glassfish.jersey.server.ServerProperties;
 import org.kiwiproject.validation.KiwiValidations;

--- a/src/main/java/org/kiwiproject/dropwizard/util/exception/EarlyEofExceptionMapper.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/exception/EarlyEofExceptionMapper.java
@@ -1,14 +1,13 @@
 package org.kiwiproject.dropwizard.util.exception;
 
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.io.EofException;
 import org.kiwiproject.jaxrs.exception.JaxrsBadRequestException;
 import org.kiwiproject.jaxrs.exception.JaxrsException;
 import org.kiwiproject.jaxrs.exception.JaxrsExceptionMapper;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
 
 /**
  * Override default Dropwizard mapper to use kiwi's {@link org.kiwiproject.jaxrs.exception.ErrorMessage ErrorMessage}.

--- a/src/main/java/org/kiwiproject/dropwizard/util/exception/EmptyOptionalExceptionMapper.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/exception/EmptyOptionalExceptionMapper.java
@@ -1,13 +1,12 @@
 package org.kiwiproject.dropwizard.util.exception;
 
 import io.dropwizard.jersey.optional.EmptyOptionalException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 import org.kiwiproject.jaxrs.exception.JaxrsException;
 import org.kiwiproject.jaxrs.exception.JaxrsExceptionMapper;
 import org.kiwiproject.jaxrs.exception.JaxrsNotFoundException;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
 
 /**
  * Override default Dropwizard mapper to use kiwi's {@link org.kiwiproject.jaxrs.exception.ErrorMessage ErrorMessage}.

--- a/src/main/java/org/kiwiproject/dropwizard/util/exception/JerseyViolationExceptionMapper.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/exception/JerseyViolationExceptionMapper.java
@@ -1,13 +1,12 @@
 package org.kiwiproject.dropwizard.util.exception;
 
 import io.dropwizard.jersey.validation.JerseyViolationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 import org.kiwiproject.jaxrs.exception.ConstraintViolationExceptionMapper;
 import org.kiwiproject.jaxrs.exception.JaxrsException;
 import org.kiwiproject.jaxrs.exception.JaxrsExceptionMapper;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
 
 /**
  * Override default Dropwizard mapper to use kiwi's {@link org.kiwiproject.jaxrs.exception.ErrorMessage ErrorMessage}.

--- a/src/main/java/org/kiwiproject/dropwizard/util/exception/JsonProcessingExceptionMapper.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/exception/JsonProcessingExceptionMapper.java
@@ -3,14 +3,13 @@ package org.kiwiproject.dropwizard.util.exception;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 import lombok.extern.slf4j.Slf4j;
 import org.kiwiproject.jaxrs.exception.JaxrsBadRequestException;
 import org.kiwiproject.jaxrs.exception.JaxrsException;
 import org.kiwiproject.jaxrs.exception.JaxrsExceptionMapper;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
 
 /**
  * Override default Dropwizard mapper to use kiwi's {@link org.kiwiproject.jaxrs.exception.ErrorMessage ErrorMessage}.

--- a/src/main/java/org/kiwiproject/dropwizard/util/exception/StandardExceptionMappers.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/exception/StandardExceptionMappers.java
@@ -4,8 +4,8 @@ import static java.lang.invoke.MethodType.methodType;
 import static org.kiwiproject.base.KiwiStrings.format;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.dropwizard.server.ServerFactory;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.server.ServerFactory;
+import io.dropwizard.core.setup.Environment;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.kiwiproject.jaxrs.exception.ConstraintViolationExceptionMapper;

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/HttpConnectionsHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/HttpConnectionsHealthCheck.java
@@ -25,12 +25,12 @@ import java.util.SortedMap;
 
 /**
  * Health check that checks the percent of leased connections against the maximum number of connections for
- * JAX-RS {@link javax.ws.rs.client.Client} instances that were created using Dropwizard's
+ * JAX-RS {@link jakarta.ws.rs.client.Client} instances that were created using Dropwizard's
  * {@code io.dropwizard.client.JerseyClientBuilder}, which creates an HTTP connection pool and registers various
  * connection metrics that we can query.
  * <p>
- * Please note, if using a default JAX-RS {@link javax.ws.rs.client.Client} created using the normal
- * {@link javax.ws.rs.client.ClientBuilder}, those clients will <em>not</em> have metrics registered and will therefore
+ * Please note, if using a default JAX-RS {@link jakarta.ws.rs.client.Client} created using the normal
+ * {@link jakarta.ws.rs.client.ClientBuilder}, those clients will <em>not</em> have metrics registered and will therefore
  * <em>not</em> be included by this check (since it won't know about them).
  */
 @Slf4j

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/MongoHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/MongoHealthCheck.java
@@ -4,16 +4,14 @@ import static org.kiwiproject.base.KiwiStrings.f;
 import static org.kiwiproject.metrics.health.HealthCheckResults.newResultBuilder;
 import static org.kiwiproject.metrics.health.HealthCheckResults.newUnhealthyResult;
 
-import java.util.Optional;
-
 import com.codahale.metrics.health.HealthCheck;
 import com.mongodb.client.MongoDatabase;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.Document;
+
+import java.util.Optional;
 
 /**
  * Health check that attempts to issue a 'ping' command to a Mongo database.
@@ -94,8 +92,8 @@ public class MongoHealthCheck extends HealthCheck {
      * for a boolean first.
      */
     private static boolean ok(Object okValue) {
-        if (okValue instanceof Number) {
-            return ((Number) okValue).intValue() == 1;
+        if (okValue instanceof Number number) {
+            return number.intValue() == 1;
         } else if (okValue instanceof Boolean) {
             return (boolean) okValue;
         } else {

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/ServicePingHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/ServicePingHealthCheck.java
@@ -10,6 +10,7 @@ import static org.kiwiproject.metrics.health.HealthCheckResults.newUnhealthyResu
 import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.google.common.annotations.VisibleForTesting;
+import jakarta.ws.rs.client.WebTarget;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.text.WordUtils;
 import org.kiwiproject.jaxrs.KiwiResponses;
@@ -19,7 +20,6 @@ import org.kiwiproject.jersey.client.exception.MissingServiceRuntimeException;
 import org.kiwiproject.metrics.health.HealthStatus;
 import org.kiwiproject.registry.model.Port.PortType;
 
-import javax.ws.rs.client.WebTarget;
 import java.util.stream.Stream;
 
 /**

--- a/src/main/java/org/kiwiproject/dropwizard/util/jackson/StandardJacksonConfigurations.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/jackson/StandardJacksonConfigurations.java
@@ -3,7 +3,8 @@ package org.kiwiproject.dropwizard.util.jackson;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
+import jakarta.xml.bind.JAXBElement;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.kiwiproject.dropwizard.util.config.JacksonConfig;
@@ -11,8 +12,6 @@ import org.kiwiproject.dropwizard.util.health.UnknownPropertiesHealthCheck;
 import org.kiwiproject.json.JaxbElementSerializer;
 import org.kiwiproject.json.JsonHelper;
 import org.kiwiproject.json.LoggingDeserializationProblemHandler;
-
-import javax.xml.bind.JAXBElement;
 
 /**
  * Set of opinionated "standard" utilities to configure Jackson.

--- a/src/main/java/org/kiwiproject/dropwizard/util/job/JobErrorHandlers.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/job/JobErrorHandlers.java
@@ -57,13 +57,7 @@ public class JobErrorHandlers {
         }
     }
 
-    private static class CustomLoggerJobErrorHandler implements JobErrorHandler {
-
-        private final Logger customLogger;
-
-        private CustomLoggerJobErrorHandler(Logger customLogger) {
-            this.customLogger = customLogger;
-        }
+    private record CustomLoggerJobErrorHandler(Logger customLogger) implements JobErrorHandler {
 
         @Override
         public void handle(MonitoredJob job, Exception exception) {

--- a/src/main/java/org/kiwiproject/dropwizard/util/job/MonitoredJobs.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/job/MonitoredJobs.java
@@ -8,7 +8,7 @@ import static org.kiwiproject.base.KiwiStrings.f;
 import static org.kiwiproject.dropwizard.util.lifecycle.StandardLifecycles.newScheduledExecutor;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.kiwiproject.base.KiwiEnvironment;
@@ -261,7 +261,7 @@ public class MonitoredJobs {
          * supplied if necessary.
          *
          * @return the new job instance
-         * @throws IllegalArgumentException if task, name, environment, or schedule has not been specified
+         * @throws IllegalArgumentException if the task, name, environment, or schedule has not been specified
          * @see #registerJob(Environment, MonitoredJob, JobSchedule, ScheduledExecutorService)
          */
         public MonitoredJob registerJob() {

--- a/src/main/java/org/kiwiproject/dropwizard/util/lifecycle/StandardLifecycles.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/lifecycle/StandardLifecycles.java
@@ -4,7 +4,7 @@ import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.base.KiwiStrings.f;
 
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.kiwiproject.registry.config.ServiceInfo;
@@ -47,7 +47,7 @@ public class StandardLifecycles {
      *
      * @param registryService a pre-built {@link RegistryService} that will connect to a service discovery for
      *                        registration/un-registration
-     * @param serviceInfo     the metadata about the service (i.e. name, version, etc)
+     * @param serviceInfo     the metadata about the service (i.e. name, version, etc.)
      * @param environment     the Dropwizard environment
      */
     public static void addRegistryLifecycleListeners(RegistryService registryService,
@@ -62,7 +62,7 @@ public class StandardLifecycles {
         environment.lifecycle().addServerLifecycleListener(listener);
 
         // Handles unregistering at shutdown
-        environment.lifecycle().addLifeCycleListener(listener);
+        environment.lifecycle().addEventListener(listener);
     }
 
     /**
@@ -116,7 +116,7 @@ public class StandardLifecycles {
     /**
      * Adds a lifecycle listener to print out the status of the server with configured ports at startup.
      *
-     * @param serviceInfo the metadata about the service (i.e. name, version, etc)
+     * @param serviceInfo the metadata about the service (i.e. name, version, etc.)
      * @param environment the Dropwizard environment
      */
     public static void addServiceRunningLifecycleListener(ServiceInfo serviceInfo, Environment environment) {

--- a/src/main/java/org/kiwiproject/dropwizard/util/resource/ConfigResource.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/resource/ConfigResource.java
@@ -1,19 +1,19 @@
 package org.kiwiproject.dropwizard.util.resource;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.kiwiproject.json.KiwiJacksonSerializers.buildPropertyMaskingSafeSerializerModule;
 
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import io.dropwizard.Configuration;
+import io.dropwizard.core.Configuration;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
 import org.kiwiproject.json.JsonHelper;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.function.Consumer;
 

--- a/src/main/java/org/kiwiproject/dropwizard/util/server/DropwizardConnectors.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/server/DropwizardConnectors.java
@@ -6,11 +6,11 @@ import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.base.KiwiStrings.format;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.dropwizard.core.server.DefaultServerFactory;
+import io.dropwizard.core.server.ServerFactory;
 import io.dropwizard.jetty.ConnectorFactory;
 import io.dropwizard.jetty.HttpConnectorFactory;
 import io.dropwizard.jetty.HttpsConnectorFactory;
-import io.dropwizard.server.DefaultServerFactory;
-import io.dropwizard.server.ServerFactory;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
@@ -59,11 +59,12 @@ public class DropwizardConnectors {
     public static DefaultServerFactory requireDefaultServerFactory(ServerFactory serverFactory) {
         checkArgumentNotNull(serverFactory, "ServerFactory is required");
 
-        if (serverFactory instanceof DefaultServerFactory) {
-            return (DefaultServerFactory) serverFactory;
+        if (serverFactory instanceof DefaultServerFactory defaultServerFactory) {
+            return defaultServerFactory;
         }
 
-        var error = format("The server factory is not a {} (it is a {})", DefaultServerFactory.class.getName(), serverFactory.getClass().getName());
+        var error = format("The server factory is not a {} (it is a {})",
+                DefaultServerFactory.class.getName(), serverFactory.getClass().getName());
         throw new IllegalStateException(error);
     }
 

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/PortAssigner.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/PortAssigner.java
@@ -7,10 +7,10 @@ import static org.kiwiproject.collect.KiwiLists.first;
 import static org.kiwiproject.dropwizard.util.server.DropwizardConnectors.requireDefaultServerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.dropwizard.core.server.DefaultServerFactory;
+import io.dropwizard.core.server.ServerFactory;
 import io.dropwizard.jetty.HttpConnectorFactory;
 import io.dropwizard.jetty.HttpsConnectorFactory;
-import io.dropwizard.server.DefaultServerFactory;
-import io.dropwizard.server.ServerFactory;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/StartupLocker.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/StartupLocker.java
@@ -2,7 +2,7 @@ package org.kiwiproject.dropwizard.util.startup;
 
 import static org.kiwiproject.base.KiwiStrings.format;
 
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.util.Duration;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -78,7 +78,7 @@ public class StartupLocker {
 
             try {
                 tryAcquireStartupLock(lock, lockPath, lockTimeout);
-                environment.lifecycle().addLifeCycleListener(
+                environment.lifecycle().addEventListener(
                         new StartupWithLockJettyLifeCycleListener(curatorFramework, lock, lockPath, executioner));
 
                 return StartupLockInfo.builder()
@@ -120,7 +120,7 @@ public class StartupLocker {
      */
     public void addFallbackJettyStartupLifeCycleListener(StartupLockInfo lockInfo, Environment environment) {
         if (lockInfo.getLockState() != StartupLockInfo.LockState.ACQUIRED) {
-            environment.lifecycle().addLifeCycleListener(new StartupJettyLifeCycleListener(executioner));
+            environment.lifecycle().addEventListener(new StartupJettyLifeCycleListener(executioner));
         }
     }
 

--- a/src/test/java/org/kiwiproject/dropwizard/util/admin/AdminConfiguratorTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/admin/AdminConfiguratorTest.java
@@ -8,9 +8,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.dropwizard.Configuration;
-import io.dropwizard.setup.AdminEnvironment;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.Configuration;
+import io.dropwizard.core.setup.AdminEnvironment;
+import io.dropwizard.core.setup.Environment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/org/kiwiproject/dropwizard/util/environment/StandardEnvironmentConfigurationsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/environment/StandardEnvironmentConfigurationsTest.java
@@ -7,14 +7,13 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jersey.DropwizardResourceConfig;
+import jakarta.validation.Validator;
 import org.glassfish.jersey.server.ServerProperties;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.kiwiproject.test.dropwizard.mockito.DropwizardMockitoMocks;
 import org.kiwiproject.validation.KiwiValidations;
-
-import javax.validation.Validator;
 
 @DisplayName("StandardEnvironmentConfigurations")
 class StandardEnvironmentConfigurationsTest {

--- a/src/test/java/org/kiwiproject/dropwizard/util/exception/ErrorMessageAssertions.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/exception/ErrorMessageAssertions.java
@@ -3,10 +3,10 @@ package org.kiwiproject.dropwizard.util.exception;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.kiwiproject.collect.KiwiLists.first;
 
+import jakarta.ws.rs.core.Response;
 import lombok.experimental.UtilityClass;
 import org.kiwiproject.jaxrs.exception.ErrorMessage;
 
-import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.Map;
 

--- a/src/test/java/org/kiwiproject/dropwizard/util/exception/LoggingExceptionMapperTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/exception/LoggingExceptionMapperTest.java
@@ -6,6 +6,7 @@ import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertBadRequest;
 import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertConflict;
 import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertInternalServerErrorResponse;
 
+import jakarta.ws.rs.WebApplicationException;
 import org.hibernate.dialect.lock.OptimisticEntityLockException;
 import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.DisplayName;
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.OptimisticLockingFailureException;
 
-import javax.ws.rs.WebApplicationException;
 import java.sql.SQLException;
 
 @SuppressWarnings("rawtypes")

--- a/src/test/java/org/kiwiproject/dropwizard/util/exception/StandardExceptionMappersTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/exception/StandardExceptionMappersTest.java
@@ -7,9 +7,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.verify;
 
-import io.dropwizard.server.DefaultServerFactory;
-import io.dropwizard.server.ServerFactory;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.server.DefaultServerFactory;
+import io.dropwizard.core.server.ServerFactory;
+import io.dropwizard.core.setup.Environment;
 import org.eclipse.jetty.server.Server;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/org/kiwiproject/dropwizard/util/health/ServicePingHealthCheckTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/health/ServicePingHealthCheckTest.java
@@ -12,6 +12,11 @@ import static org.mockito.Mockito.when;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import io.dropwizard.testing.junit5.DropwizardClientExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,11 +35,6 @@ import org.kiwiproject.registry.model.ServiceInstance;
 import org.kiwiproject.registry.model.ServicePaths;
 import org.mockito.ArgumentCaptor;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/test/java/org/kiwiproject/dropwizard/util/health/keystore/KeystoreHealthResultsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/health/keystore/KeystoreHealthResultsTest.java
@@ -1,6 +1,5 @@
 package org.kiwiproject.dropwizard.util.health.keystore;
 
-import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.kiwiproject.test.assertj.dropwizard.metrics.HealthCheckResultAssertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -176,7 +175,7 @@ class KeystoreHealthResultsTest {
                             .expiresOnUTC(expirationDate)
                             .expiresOn(DateTimeFormatter.RFC_1123_DATE_TIME.format(expirationDate))
                             .build())
-                    .collect(toUnmodifiableList());
+                    .toList();
 
             return KeystoreHealthResults.builder()
                     .kiwiEnvironment(kiwiEnvironment)

--- a/src/test/java/org/kiwiproject/dropwizard/util/jackson/StandardJacksonConfigurationsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/jackson/StandardJacksonConfigurationsTest.java
@@ -13,9 +13,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.validation.Validator;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementRef;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.Value;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -25,11 +29,6 @@ import org.kiwiproject.json.JsonHelper;
 import org.kiwiproject.json.LoggingDeserializationProblemHandler;
 import org.kiwiproject.test.dropwizard.mockito.DropwizardMockitoMocks;
 
-import javax.validation.Validator;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementRef;
-import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.namespace.QName;
 import java.time.Instant;
 import java.util.Date;
@@ -211,10 +210,7 @@ class StandardJacksonConfigurationsTest {
         }
     }
 
-    @Value
-    public static class TestTimestampBean {
-        Instant theInstant;
-        Date theDate;
+    public record TestTimestampBean(Instant theInstant, Date theDate) {
     }
 
     @Getter

--- a/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobsTest.java
@@ -10,8 +10,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.lifecycle.setup.ScheduledExecutorServiceBuilder;
-import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Duration;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.awaitility.Durations;

--- a/src/test/java/org/kiwiproject/dropwizard/util/lifecycle/StandardLifecyclesTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/lifecycle/StandardLifecyclesTest.java
@@ -8,9 +8,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.codahale.metrics.NoopMetricRegistry;
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
-import io.dropwizard.setup.Environment;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -53,7 +52,7 @@ class StandardLifecyclesTest {
 
             StandardLifecycles.addRegistryLifecycleListeners(registryService, serviceInfo, environment);
 
-            verify(environment.lifecycle()).addLifeCycleListener(any(RegistrationLifecycleListener.class));
+            verify(environment.lifecycle()).addEventListener(any(RegistrationLifecycleListener.class));
             verify(environment.lifecycle()).addServerLifecycleListener(any(RegistrationLifecycleListener.class));
         }
     }

--- a/src/test/java/org/kiwiproject/dropwizard/util/resource/ConfigResourceTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/resource/ConfigResourceTest.java
@@ -8,10 +8,10 @@ import static org.kiwiproject.test.constants.KiwiTestConstants.JSON_HELPER;
 
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
-import io.dropwizard.Application;
-import io.dropwizard.Configuration;
+import io.dropwizard.core.Application;
+import io.dropwizard.core.Configuration;
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.jackson.Jackson;
-import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import lombok.AllArgsConstructor;
@@ -68,7 +68,7 @@ class ConfigResourceTest {
 
         // problematic interface; causes empty value in JSON, e.g. { "errorLogConsumer": }
         interface RefreshErrorLogConsumer {
-            @SuppressWarnings("unused")
+            @SuppressWarnings({"unused", "EmptyMethod"})
             void accept(Logger logger, String message, Throwable error);
         }
     }

--- a/src/test/java/org/kiwiproject/dropwizard/util/server/DropwizardConnectorsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/server/DropwizardConnectorsTest.java
@@ -5,12 +5,12 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.core.server.DefaultServerFactory;
+import io.dropwizard.core.server.ServerFactory;
+import io.dropwizard.core.server.SimpleServerFactory;
 import io.dropwizard.jetty.ConnectorFactory;
 import io.dropwizard.jetty.HttpConnectorFactory;
 import io.dropwizard.jetty.HttpsConnectorFactory;
-import io.dropwizard.server.DefaultServerFactory;
-import io.dropwizard.server.ServerFactory;
-import io.dropwizard.server.SimpleServerFactory;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.thread.ThreadPool;
@@ -35,7 +35,7 @@ class DropwizardConnectorsTest {
             ServerFactory factory = new SimpleServerFactory();
             assertThatThrownBy(() -> DropwizardConnectors.requireDefaultServerFactory(factory))
                     .isExactlyInstanceOf(IllegalStateException.class)
-                    .hasMessageStartingWith("The server factory is not a io.dropwizard.server.DefaultServerFactory (it is a ")
+                    .hasMessageStartingWith("The server factory is not a %s (it is a ", DefaultServerFactory.class.getName())
                     .hasMessageEndingWith("SimpleServerFactory)");
         }
 

--- a/src/test/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategiesTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategiesTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.kiwiproject.test.assertj.KiwiAssertJ.assertIsExactType;
 
-import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -129,9 +128,6 @@ class ExecutionStrategiesTest {
         return new ExecResult(process.pid(), exitValueOrNull);
     }
 
-    @Value
-    private static class ExecResult {
-        long pid;
-        Integer exitValue;
+    private record ExecResult(long pid, Integer exitValue) {
     }
 }

--- a/src/test/java/org/kiwiproject/dropwizard/util/startup/PortAssignerTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/startup/PortAssignerTest.java
@@ -13,10 +13,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.dropwizard.core.server.DefaultServerFactory;
+import io.dropwizard.core.server.SimpleServerFactory;
 import io.dropwizard.jetty.HttpConnectorFactory;
 import io.dropwizard.jetty.HttpsConnectorFactory;
-import io.dropwizard.server.DefaultServerFactory;
-import io.dropwizard.server.SimpleServerFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -188,7 +188,7 @@ class PortAssignerTest {
 
                 assertThatThrownBy(portAssignerBuilder::build)
                         .isInstanceOf(IllegalStateException.class)
-                        .hasMessageStartingWith("The server factory is not a io.dropwizard.server.DefaultServerFactory (it is a ")
+                        .hasMessageStartingWith("The server factory is not a %s (it is a ", DefaultServerFactory.class.getName())
                         .hasMessageEndingWith("SimpleServerFactory)");
             }
 

--- a/src/test/java/org/kiwiproject/dropwizard/util/startup/StartupLockerTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/startup/StartupLockerTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.testing.junit5.DropwizardClientExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.util.Duration;


### PR DESCRIPTION
* Bump version to 2.0.0-SNAPSHOT
* Bump kiwi-parent from 2.0.20 to 3.0.1
* Bump kiwi-bom from 1.1.1 to 2.0.0
* Bump kiwi libraries to next major version
* Update build for JDK 17 and 20
* Update CodeQL workflow to use JDK 17
* Fix Dropwizard package changes
* Refactor from javax to jakarta namespace for Jakarta EE 9
* Change org.hibernate to org.hibernate.orm in the POM (new groupId)
* Dropwizard method addLifeCycleListener becomes addEventListener
* Code cleanup: fix relevant issues flagged by Sonar and IntelliJ, e.g. use toList on Stream, enhanced switch and switch expressions, pattern matching with instanceof, convert to record, grammar, etc.