### PR TITLE
Replace usages of deprecated methods in X509Certificate

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/health/keystore/BasicCertInfo.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/keystore/BasicCertInfo.java
@@ -32,11 +32,11 @@ class BasicCertInfo {
         var certStatus = CertStatus.determineCertStatus(now, expirationThreshold, notAfter);
 
         return builder()
-                .subjectDN(x509Cert.getSubjectDN().getName())
+                .subjectDN(x509Cert.getSubjectX500Principal().getName())
                 .issuedOn(rfc1123FormatAtUTC(x509Cert.getNotBefore().toInstant()))
                 .expiresOn(rfc1123FormatAtUTC(notAfter))
                 .expiresOnUTC(notAfter.atZone(UTC_ZONE_ID))
-                .issuerDN(x509Cert.getIssuerDN().getName())
+                .issuerDN(x509Cert.getIssuerX500Principal().getName())
                 .certStatus(certStatus)
                 .build();
     }

--- a/src/test/java/org/kiwiproject/dropwizard/util/health/keystore/ExpiringKeystoreHealthCheckTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/health/keystore/ExpiringKeystoreHealthCheckTest.java
@@ -70,8 +70,10 @@ class ExpiringKeystoreHealthCheckTest {
             softly.assertThat(expiredCerts).hasSize(1);
 
             var certInfo = first(expiredCerts);
-            softly.assertThat(certInfo.getSubjectDN()).isEqualTo("CN=Unit Test, OU=Development, O=Project, L=Here, ST=VA, C=US");
-            softly.assertThat(certInfo.getIssuerDN()).isEqualTo("CN=Unit Test, OU=Development, O=Project, L=Here, ST=VA, C=US");
+            softly.assertThat(certInfo.getSubjectDN())
+                    .isEqualToIgnoringWhitespace("CN=Unit Test, OU=Development, O=Project, L=Here, ST=VA, C=US");
+            softly.assertThat(certInfo.getIssuerDN())
+                    .isEqualToIgnoringWhitespace("CN=Unit Test, OU=Development, O=Project, L=Here, ST=VA, C=US");
 
             var sixtyDaysAgo = ZonedDateTime.now().minusDays(60).toInstant().atZone(ZoneId.of("UTC"));
             var sixtyDaysAgoString = DATE_FORMATTER.format(sixtyDaysAgo);
@@ -119,8 +121,10 @@ class ExpiringKeystoreHealthCheckTest {
             softly.assertThat(expiringCerts).hasSize(1);
 
             var certInfo = first(expiringCerts);
-            softly.assertThat(certInfo.getSubjectDN()).isEqualTo("CN=Unit Test, OU=Development, O=Project, L=Here, ST=VA, C=US");
-            softly.assertThat(certInfo.getIssuerDN()).isEqualTo("CN=Unit Test, OU=Development, O=Project, L=Here, ST=VA, C=US");
+            softly.assertThat(certInfo.getSubjectDN())
+                    .isEqualToIgnoringWhitespace("CN=Unit Test, OU=Development, O=Project, L=Here, ST=VA, C=US");
+            softly.assertThat(certInfo.getIssuerDN())
+                    .isEqualToIgnoringWhitespace("CN=Unit Test, OU=Development, O=Project, L=Here, ST=VA, C=US");
 
             var sixtyDaysAgo = ZonedDateTime.now().minusDays(60).toInstant().atZone(ZoneId.of("UTC"));
             var sixtyDaysAgoString = DATE_FORMATTER.format(sixtyDaysAgo);
@@ -200,8 +204,10 @@ class ExpiringKeystoreHealthCheckTest {
             softly.assertThat(validCerts).hasSize(1);
 
             var certInfo = first(validCerts);
-            softly.assertThat(certInfo.getSubjectDN()).isEqualTo("CN=Valid Test, OU=Development, O=Project, L=There, ST=VA, C=US");
-            softly.assertThat(certInfo.getIssuerDN()).isEqualTo("CN=Valid Test, OU=Development, O=Project, L=There, ST=VA, C=US");
+            softly.assertThat(certInfo.getSubjectDN())
+                    .isEqualToIgnoringWhitespace("CN=Valid Test, OU=Development, O=Project, L=There, ST=VA, C=US");
+            softly.assertThat(certInfo.getIssuerDN())
+                    .isEqualToIgnoringWhitespace("CN=Valid Test, OU=Development, O=Project, L=There, ST=VA, C=US");
 
             var sixtyDaysAgo = ZonedDateTime.now().minusDays(60).toInstant().atZone(ZoneId.of("UTC"));
             var sixtyDaysAgoString = DATE_FORMATTER.format(sixtyDaysAgo);


### PR DESCRIPTION
* Use getSubjectX500Principal instead of getSubjectDN
* Use getIssuerX500Principal instead of getIssuerDN

Note that calling getName on the returned X500Principal apparently removes the spaces after the commas in the distinguished names. This is why I changed the tests to ignore whitespace.