### PR TITLE
Retain information about the most recent exception in MonitoredJob

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/job/JobExceptionInfo.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/job/JobExceptionInfo.java
@@ -1,0 +1,51 @@
+package org.kiwiproject.dropwizard.util.job;
+
+import static java.util.Objects.nonNull;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.kiwiproject.base.KiwiThrowables;
+
+/**
+ * Contains basic metadata about an Exception that occurred during job execution.
+ *
+ * @param type             the type of Exception, may not be blank
+ * @param message          the message from the Exception, may be null
+ * @param rootCauseType    the type of the root cause Exception, may be null
+ * @param rootCauseMessage the message from the root cause Exception, may be null
+ */
+public record JobExceptionInfo(
+        String type,
+        @Nullable String message,
+        @Nullable String rootCauseType,
+        @Nullable String rootCauseMessage) {
+    public JobExceptionInfo {
+        checkArgumentNotBlank(type, "type must not be blank");
+    }
+
+    /**
+     * Creates a JobExceptionInfo object from the given Exception.
+     *
+     * @param e the Exception from which to create the JobExceptionInfo
+     * @return a new instance
+     */
+    public static JobExceptionInfo from(Exception e) {
+        checkArgumentNotNull(e, "exception must not be null");
+
+        var rootCause = KiwiThrowables.rootCauseOf(e).orElse(null);
+
+        String rootCauseType = null;
+        String rootCauseMessage = null;
+        if (nonNull(rootCause) && rootCause != e) {
+            rootCauseType = KiwiThrowables.typeOf(rootCause);
+            rootCauseMessage = KiwiThrowables.messageOf(rootCause).orElse(null);
+        }
+
+        return new JobExceptionInfo(
+                KiwiThrowables.typeOf(e),
+                KiwiThrowables.messageOf(e).orElse(null),
+                rootCauseType,
+                rootCauseMessage);
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/util/job/JobExceptionInfoTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/job/JobExceptionInfoTest.java
@@ -1,0 +1,59 @@
+package org.kiwiproject.dropwizard.util.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("JobExceptionInfo")
+class JobExceptionInfoTest {
+
+    @Test
+    void shouldCreateJobExceptionInfo() {
+        var jobExceptionInfo = new JobExceptionInfo("testType",
+                "testMessage",
+                "rootCauseType",
+                "rootCauseMessage");
+
+        assertAll(
+                () -> assertThat(jobExceptionInfo.type()).isEqualTo("testType"),
+                () -> assertThat(jobExceptionInfo.message()).isEqualTo("testMessage"),
+                () -> assertThat(jobExceptionInfo.rootCauseType()).isEqualTo("rootCauseType"),
+                () -> assertThat(jobExceptionInfo.rootCauseMessage()).isEqualTo("rootCauseMessage")
+        );
+    }
+
+    @Test
+    void shouldHandleNullValues() {
+        var jobExceptionInfo = new JobExceptionInfo("testType", null, null, null);
+
+        assertAll(
+                () -> assertThat(jobExceptionInfo.type()).isEqualTo("testType"),
+                () -> assertThat(jobExceptionInfo.message()).isNull(),
+                () -> assertThat(jobExceptionInfo.rootCauseType()).isNull(),
+                () -> assertThat(jobExceptionInfo.rootCauseMessage()).isNull()
+        );
+    }
+
+    @Test
+    void shouldRequireType() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new JobExceptionInfo(null, null, null, null))
+                .withMessage("type must not be blank");
+    }
+
+    @Test
+    void shouldReturnJobExceptionInfoFromException() {
+        var exception = new Exception("This is an Exception", new RuntimeException("Caused by a RuntimeException"));
+        var jobExceptionInfo = JobExceptionInfo.from(exception);
+
+        assertAll(
+                () -> assertThat(jobExceptionInfo.type()).isEqualTo("java.lang.Exception"),
+                () -> assertThat(jobExceptionInfo.message()).isEqualTo("This is an Exception"),
+                () -> assertThat(jobExceptionInfo.rootCauseType()).isEqualTo("java.lang.RuntimeException"),
+                () -> assertThat(jobExceptionInfo.rootCauseMessage()).isEqualTo("Caused by a RuntimeException")
+        );
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobTest.java
@@ -84,7 +84,8 @@ class MonitoredJobTest {
                     () -> assertThat(job.getLastExecutionTime().get()).isOne(),
                     () -> assertThat(job.getLastSuccess().get()).isEqualTo(mockedTime + 2),
                     () -> assertThat(job.getLastFailure().get()).isZero(),
-                    () -> assertThat(job.getFailureCount().get()).isZero()
+                    () -> assertThat(job.getFailureCount().get()).isZero(),
+                    () -> assertThat(job.getLastJobExceptionInfo()).hasValue(null)
             );
         }
 
@@ -113,7 +114,8 @@ class MonitoredJobTest {
                     () -> assertThat(job.getLastExecutionTime().get()).isOne(),
                     () -> assertThat(job.getLastSuccess().get()).isEqualTo(mockedTime + 2),
                     () -> assertThat(job.getLastFailure().get()).isZero(),
-                    () -> assertThat(job.getFailureCount().get()).isZero()
+                    () -> assertThat(job.getFailureCount().get()).isZero(),
+                    () -> assertThat(job.getLastJobExceptionInfo()).hasValue(null)
             );
         }
 
@@ -139,7 +141,8 @@ class MonitoredJobTest {
                     () -> assertThat(job.getLastExecutionTime().get()).isZero(),
                     () -> assertThat(job.getLastSuccess().get()).isEqualTo(mockedTime),
                     () -> assertThat(job.getLastFailure().get()).isZero(),
-                    () -> assertThat(job.getFailureCount().get()).isZero()
+                    () -> assertThat(job.getFailureCount().get()).isZero(),
+                    () -> assertThat(job.getLastJobExceptionInfo()).hasValue(null)
             );
         }
 
@@ -163,7 +166,8 @@ class MonitoredJobTest {
                     () -> assertThat(job.getLastExecutionTime().get()).isZero(),
                     () -> assertThat(job.getLastSuccess().get()).isZero(),
                     () -> assertThat(job.getLastFailure().get()).isEqualTo(mockedTime + 1),
-                    () -> assertThat(job.getFailureCount().get()).isOne()
+                    () -> assertThat(job.getFailureCount().get()).isOne(),
+                    () -> assertThat(job.getLastJobExceptionInfo()).hasValue(JobExceptionInfo.from(newSampleException()))
             );
         }
 
@@ -197,7 +201,8 @@ class MonitoredJobTest {
                     () -> assertThat(job.getLastSuccess().get()).isZero(),
                     () -> assertThat(job.getLastFailure().get()).isEqualTo(mockedTime + 1),
                     () -> assertThat(job.getFailureCount().get()).isOne(),
-                    () -> assertThat(taskHandledCount.get()).isOne()
+                    () -> assertThat(taskHandledCount.get()).isOne(),
+                    () -> assertThat(job.getLastJobExceptionInfo()).hasValue(JobExceptionInfo.from(newSampleException()))
             );
         }
 
@@ -247,6 +252,10 @@ class MonitoredJobTest {
     }
 
     private static void throwException() {
-        throw new RuntimeException("oops");
+        throw newSampleException();
+    }
+
+    private static RuntimeException newSampleException() {
+        return new RuntimeException("oops");
     }
 }


### PR DESCRIPTION
* Add JobExceptionInfo record to contain exception metadata
* Update MonitoredJob to set an AtomicReference containing a JobExceptionInfo object in handleExceptionSafely
* JobExceptionInfoTest mostly courtesy of JetBrains AI !

Closes #392