### PR TITLE
Add methods to control Jersey feature auto-discovery

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/environment/StandardEnvironmentConfigurations.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/environment/StandardEnvironmentConfigurations.java
@@ -2,6 +2,8 @@ package org.kiwiproject.dropwizard.util.environment;
 
 import io.dropwizard.core.setup.Environment;
 import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.glassfish.jersey.CommonProperties;
 import org.glassfish.jersey.server.ServerProperties;
 import org.kiwiproject.validation.KiwiValidations;
 
@@ -11,7 +13,19 @@ import java.util.Map;
  * Set of utilities that assist in setting up the Dropwizard environment
  */
 @UtilityClass
+@Slf4j
 public class StandardEnvironmentConfigurations {
+
+    /**
+     * An enum that describes whether a Jersey feature is enabled or disabled.
+     *
+     * @see CommonProperties
+     * @see ServerProperties
+     * @see org.glassfish.jersey.client.ClientProperties ClientProperties
+     */
+    public enum JerseyFeatureStatus {
+        DISABLED, ENABLED
+    }
 
     /**
      * Enables the generation of the WADL endpoint in the Dropwizard service
@@ -19,10 +33,58 @@ public class StandardEnvironmentConfigurations {
      * NOTE: Only call this if you want the WADL generation, the default in Dropwizard is to have this disabled.
      *
      * @param environment the Dropwizard environment
+     * @see ServerProperties#WADL_FEATURE_DISABLE
      */
     public static void enableWadlGeneration(Environment environment) {
         Map<String, Object> properties = Map.of(ServerProperties.WADL_FEATURE_DISABLE, false);
         environment.jersey().getResourceConfig().addProperties(properties);
+    }
+
+    /**
+     * Disables auto-discovery of Jersey {@link jakarta.ws.rs.core.Feature Feature}s
+     * <em>globally</em> on both client and server.
+     * <p>
+     * By default, Jersey feature auto-discovery is automatically enabled.
+     * <p>
+     * For more information, see the section in the Jersey User Guide on
+     * <em>Auto-Discoverable Features</em> in the <em>Application Deployment and Runtime Environments</em>
+     * chapter.
+     *
+     * @param environment the Dropwizard environment
+     * @see CommonProperties#FEATURE_AUTO_DISCOVERY_DISABLE
+     */
+    public static void disableJacksonFeatureAutoDiscovery(Environment environment) {
+        jacksonFeatureAutoDiscovery(environment, JerseyFeatureStatus.DISABLED);
+    }
+
+    /**
+     * Sets auto-discovery of Jersey {@link jakarta.ws.rs.core.Feature Feature}s
+     * <em>globally</em> for both client and server to the given {@code featureStatus}.
+     * <p>
+     * By default, Jersey feature auto-discovery is automatically enabled.
+     * <p>
+     * For more information, see the section in the Jersey User Guide on
+     * <em>Auto-Discoverable Features</em> in the <em>Application Deployment and Runtime Environments</em>
+     * chapter.
+     *
+     * @param environment   the Dropwizard environment
+     * @param featureStatus the Jersey feature status
+     * @see CommonProperties#FEATURE_AUTO_DISCOVERY_DISABLE
+     */
+    public static void jacksonFeatureAutoDiscovery(Environment environment, JerseyFeatureStatus featureStatus) {
+        var disable = (featureStatus == JerseyFeatureStatus.DISABLED);
+
+        if (disable) {
+            LOG.warn("Disabling Jersey feature auto-discovery globally on client and server." +
+                    " If there are components that depend on feature auto-discovery, they will NOT work!" +
+                    " One common component that uses feature auto-discovery is jersey-media-json-jackson," +
+                    " which uses it to register JacksonFeature, but which can cause conflicts such as with" +
+                    " Dropwizard's own JacksonFeature. See the 'Auto-Discoverable Features' section in the" +
+                    " Jersey user guide for more information.");
+        }
+
+        environment.jersey().getResourceConfig()
+                .property(CommonProperties.FEATURE_AUTO_DISCOVERY_DISABLE, disable);
     }
 
     /**

--- a/src/main/java/org/kiwiproject/dropwizard/util/environment/StandardEnvironmentConfigurations.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/environment/StandardEnvironmentConfigurations.java
@@ -1,5 +1,6 @@
 package org.kiwiproject.dropwizard.util.environment;
 
+import com.google.common.annotations.Beta;
 import io.dropwizard.core.setup.Environment;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +24,7 @@ public class StandardEnvironmentConfigurations {
      * @see ServerProperties
      * @see org.glassfish.jersey.client.ClientProperties ClientProperties
      */
+    @Beta
     public enum JerseyFeatureStatus {
         DISABLED, ENABLED
     }
@@ -53,6 +55,7 @@ public class StandardEnvironmentConfigurations {
      * @param environment the Dropwizard environment
      * @see CommonProperties#FEATURE_AUTO_DISCOVERY_DISABLE
      */
+    @Beta
     public static void disableJacksonFeatureAutoDiscovery(Environment environment) {
         jacksonFeatureAutoDiscovery(environment, JerseyFeatureStatus.DISABLED);
     }
@@ -71,6 +74,7 @@ public class StandardEnvironmentConfigurations {
      * @param featureStatus the Jersey feature status
      * @see CommonProperties#FEATURE_AUTO_DISCOVERY_DISABLE
      */
+    @Beta
     public static void jacksonFeatureAutoDiscovery(Environment environment, JerseyFeatureStatus featureStatus) {
         var disable = (featureStatus == JerseyFeatureStatus.DISABLED);
 

--- a/src/test/java/org/kiwiproject/dropwizard/util/environment/StandardEnvironmentConfigurationsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/environment/StandardEnvironmentConfigurationsTest.java
@@ -8,10 +8,14 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import jakarta.validation.Validator;
+import org.glassfish.jersey.CommonProperties;
 import org.glassfish.jersey.server.ServerProperties;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.kiwiproject.dropwizard.util.environment.StandardEnvironmentConfigurations.JerseyFeatureStatus;
 import org.kiwiproject.test.dropwizard.mockito.DropwizardMockitoMocks;
 import org.kiwiproject.validation.KiwiValidations;
 
@@ -31,6 +35,44 @@ class StandardEnvironmentConfigurationsTest {
             StandardEnvironmentConfigurations.enableWadlGeneration(environment);
 
             assertThat(resourceConfig.getProperties()).contains(entry(ServerProperties.WADL_FEATURE_DISABLE, false));
+        }
+    }
+
+    @Nested
+    class DisableJacksonFeatureAutoDiscovery {
+
+        @Test
+        void shouldDisableJacksonFeatureAutoDiscovery() {
+            var resourceConfig = new DropwizardResourceConfig();
+            var environment = DropwizardMockitoMocks.mockEnvironment();
+
+            when(environment.jersey().getResourceConfig()).thenReturn(resourceConfig);
+
+            StandardEnvironmentConfigurations.disableJacksonFeatureAutoDiscovery(environment);
+
+            assertThat(resourceConfig.getProperty(CommonProperties.FEATURE_AUTO_DISCOVERY_DISABLE))
+                    .isEqualTo(true);
+        }
+    }
+
+    @Nested
+    class JacksonFeatureAutoDiscovery {
+
+        @ParameterizedTest
+        @CsvSource(textBlock = """
+                DISABLED, true,
+                ENABLED, false
+                """)
+        void shouldEnableOrDisable(JerseyFeatureStatus featureStatus, boolean expectedPropertyValue) {
+            var resourceConfig = new DropwizardResourceConfig();
+            var environment = DropwizardMockitoMocks.mockEnvironment();
+
+            when(environment.jersey().getResourceConfig()).thenReturn(resourceConfig);
+
+            StandardEnvironmentConfigurations.jacksonFeatureAutoDiscovery(environment, featureStatus);
+
+            assertThat(resourceConfig.getProperty(CommonProperties.FEATURE_AUTO_DISCOVERY_DISABLE))
+                    .isEqualTo(expectedPropertyValue);
         }
     }
 


### PR DESCRIPTION
* Add two methods to StandardEnvironmentConfigurations which provide an easy way to control whether Jersey feature auto-discovery is enabled or disabled.
* Add a new enum, JerseyFeatureStatus, to describe whether a feature should be enabled or disabled
* Both of these methods and then enum are marked as beta features to provide for future API changes

Closes #415