### PR TITLE
Rename Jersey feature-autodiscovery methods

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/environment/StandardEnvironmentConfigurations.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/environment/StandardEnvironmentConfigurations.java
@@ -56,8 +56,8 @@ public class StandardEnvironmentConfigurations {
      * @see CommonProperties#FEATURE_AUTO_DISCOVERY_DISABLE
      */
     @Beta
-    public static void disableJacksonFeatureAutoDiscovery(Environment environment) {
-        jacksonFeatureAutoDiscovery(environment, JerseyFeatureStatus.DISABLED);
+    public static void disableJerseyFeatureAutoDiscovery(Environment environment) {
+        jerseyFeatureAutoDiscovery(environment, JerseyFeatureStatus.DISABLED);
     }
 
     /**
@@ -75,7 +75,7 @@ public class StandardEnvironmentConfigurations {
      * @see CommonProperties#FEATURE_AUTO_DISCOVERY_DISABLE
      */
     @Beta
-    public static void jacksonFeatureAutoDiscovery(Environment environment, JerseyFeatureStatus featureStatus) {
+    public static void jerseyFeatureAutoDiscovery(Environment environment, JerseyFeatureStatus featureStatus) {
         var disable = (featureStatus == JerseyFeatureStatus.DISABLED);
 
         if (disable) {

--- a/src/test/java/org/kiwiproject/dropwizard/util/environment/StandardEnvironmentConfigurationsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/environment/StandardEnvironmentConfigurationsTest.java
@@ -39,16 +39,16 @@ class StandardEnvironmentConfigurationsTest {
     }
 
     @Nested
-    class DisableJacksonFeatureAutoDiscovery {
+    class DisableJerseyFeatureAutoDiscovery {
 
         @Test
-        void shouldDisableJacksonFeatureAutoDiscovery() {
+        void shouldDisableJerseyFeatureAutoDiscovery() {
             var resourceConfig = new DropwizardResourceConfig();
             var environment = DropwizardMockitoMocks.mockEnvironment();
 
             when(environment.jersey().getResourceConfig()).thenReturn(resourceConfig);
 
-            StandardEnvironmentConfigurations.disableJacksonFeatureAutoDiscovery(environment);
+            StandardEnvironmentConfigurations.disableJerseyFeatureAutoDiscovery(environment);
 
             assertThat(resourceConfig.getProperty(CommonProperties.FEATURE_AUTO_DISCOVERY_DISABLE))
                     .isEqualTo(true);
@@ -56,7 +56,7 @@ class StandardEnvironmentConfigurationsTest {
     }
 
     @Nested
-    class JacksonFeatureAutoDiscovery {
+    class JerseyFeatureAutoDiscovery {
 
         @ParameterizedTest
         @CsvSource(textBlock = """
@@ -69,7 +69,7 @@ class StandardEnvironmentConfigurationsTest {
 
             when(environment.jersey().getResourceConfig()).thenReturn(resourceConfig);
 
-            StandardEnvironmentConfigurations.jacksonFeatureAutoDiscovery(environment, featureStatus);
+            StandardEnvironmentConfigurations.jerseyFeatureAutoDiscovery(environment, featureStatus);
 
             assertThat(resourceConfig.getProperty(CommonProperties.FEATURE_AUTO_DISCOVERY_DISABLE))
                     .isEqualTo(expectedPropertyValue);


### PR DESCRIPTION
* Fix my mistake misnaming the Jersey feature auto-discovery methods
* They were incorrectly named with "Jackson" instead of "Jersey"
* The incorrect names were never published in a release, so there are no breaking changes

Closes #415