### PR TITLE
Register NoSuchElementExceptionMapper in StandardExceptionMappers

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/exception/StandardExceptionMappers.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/exception/StandardExceptionMappers.java
@@ -12,6 +12,7 @@ import org.kiwiproject.jaxrs.exception.ConstraintViolationExceptionMapper;
 import org.kiwiproject.jaxrs.exception.IllegalArgumentExceptionMapper;
 import org.kiwiproject.jaxrs.exception.IllegalStateExceptionMapper;
 import org.kiwiproject.jaxrs.exception.JaxrsExceptionMapper;
+import org.kiwiproject.jaxrs.exception.NoSuchElementExceptionMapper;
 import org.kiwiproject.jaxrs.exception.WebApplicationExceptionMapper;
 
 import java.lang.invoke.MethodHandle;
@@ -39,10 +40,11 @@ public class StandardExceptionMappers {
         jersey.register(new WebApplicationExceptionMapper());
         jersey.register(new IllegalArgumentExceptionMapper());
         jersey.register(new IllegalStateExceptionMapper());
+        jersey.register(new NoSuchElementExceptionMapper());
         jersey.register(new JaxrsExceptionMapper());
 
-        // Don't allow Dropwizard to register default exception mappers, since we might be overriding the default
-        // ConstraintViolationExceptionMapper (depending on configuration)
+        // Don't allow Dropwizard to register default exception mappers, since we are overriding
+        // its default exception mappers with replacements from kiwi
         disableDefaultExceptionMapperRegistration(serverFactory);
 
         // Register replacements for Dropwizard default exception mappers

--- a/src/test/java/org/kiwiproject/dropwizard/util/exception/StandardExceptionMappersTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/exception/StandardExceptionMappersTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import io.dropwizard.core.server.DefaultServerFactory;
 import io.dropwizard.core.server.ServerFactory;
@@ -18,6 +19,7 @@ import org.kiwiproject.jaxrs.exception.ConstraintViolationExceptionMapper;
 import org.kiwiproject.jaxrs.exception.IllegalArgumentExceptionMapper;
 import org.kiwiproject.jaxrs.exception.IllegalStateExceptionMapper;
 import org.kiwiproject.jaxrs.exception.JaxrsExceptionMapper;
+import org.kiwiproject.jaxrs.exception.NoSuchElementExceptionMapper;
 import org.kiwiproject.jaxrs.exception.WebApplicationExceptionMapper;
 import org.kiwiproject.test.dropwizard.mockito.DropwizardMockitoMocks;
 
@@ -46,6 +48,7 @@ class StandardExceptionMappersTest {
             verify(jersey).register(isA(WebApplicationExceptionMapper.class));
             verify(jersey).register(isA(IllegalArgumentExceptionMapper.class));
             verify(jersey).register(isA(IllegalStateExceptionMapper.class));
+            verify(jersey).register(isA(NoSuchElementExceptionMapper.class));
             verify(jersey).register(isA(JaxrsExceptionMapper.class));
 
             verify(jersey).register(any(LoggingExceptionMapper.class));
@@ -54,6 +57,8 @@ class StandardExceptionMappersTest {
             verify(jersey).register(isA(EarlyEofExceptionMapper.class));
             verify(jersey).register(isA(ConstraintViolationExceptionMapper.class));
             verify(jersey).register(isA(JerseyViolationExceptionMapper.class));
+
+            verifyNoMoreInteractions(jersey);
         }
     }
 


### PR DESCRIPTION
This makes NoSuchElementExceptionMapper one of our "standard" exception mappers. This is unique to kiwi and does not replace an existing Dropwizard exception mapper.

Closes #424