### PR TITLE
Improve PortAssigner#assignDynamicPorts javadocs

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/PortAssigner.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/PortAssigner.java
@@ -73,12 +73,22 @@ public class PortAssigner {
     }
 
     /**
-     * Sets up the connectors with a dynamic available port if {@link PortAssigner} is configured for dynamic ports.
-     *
-     * @implNote When using {@link PortSecurity#SECURE}, the current implementation <strong>replaces</strong> the
+     * Sets up the application and admin connectors with a dynamic available port
+     * if {@link PortAssigner} is configured for dynamic ports.
+     * <p>
+     * When using {@link PortSecurity#NON_SECURE HTTP},
+     * only the <em>first</em> application and admin connectors have dynamic ports assigned.
+     * If an application is using multiple connectors, it's best to avoid using this class
+     * unless you only want the first ones dynamically assigned.
+     * <p>
+     * When using {@link PortSecurity#SECURE HTTPS}, the current implementation <strong>replaces</strong> the
      * application and admin connector factories, which overrides any explicit configuration.
      * Support for explicit configuration of secure connectors while still assigning dynamics ports may
      * be implemented in the future if custom configuration is needed.
+     * <p>
+     * <strong>WARNING</strong>: If you need to change specific properties of secure ports,
+     * or need more than one secure application and/or admin port, you can't use this
+     * class, since it will replace all other ports!
      */
     public void assignDynamicPorts() {
         if (portAssignment == PortAssignment.STATIC) {
@@ -94,7 +104,7 @@ public class PortAssigner {
     }
 
     private void assignSecureDynamicPorts() {
-        LOG.debug("Secure (https): replace Dropwizard HTTP app/admin connectors with HTTPS ones using dynamic ports");
+        LOG.debug("Secure (https): *replace* Dropwizard HTTP app/admin connectors with HTTPS ones using dynamic ports");
 
         var usedPorts = new HashSet<Integer>();
 

--- a/src/test/java/org/kiwiproject/dropwizard/util/resource/ConfigResourceTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/resource/ConfigResourceTest.java
@@ -40,7 +40,7 @@ class ConfigResourceTest {
     @Getter
     @Setter
     @AllArgsConstructor
-    static class TestConfig extends Configuration {
+    public static class TestConfig extends Configuration {
         private String someNeededProperty;
         private String someHiddenPassword;
         private CacheConfig cacheConfig;


### PR DESCRIPTION
* Add more details to the javadoc to better explain the differences in behavior when using HTTP vs HTTPS ports.
* Emphasize the word 'replace' in a debugging log message.
* Make the TestConfig nested class public inside ConfigResourceTest, because IntelliJ flagged this as a case where the class using it (TestApp) was public and had more visibility than a class it was using. While this didn't cause the test any problems, better to listen to IntelliJ when it tells you something! And it's correct that normally, this would have been an issue in production code.

Closes #428