### PR TITLE
Add bundle that acquires a distributed lock during startup

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/bundle/PortAssigners.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/bundle/PortAssigners.java
@@ -13,6 +13,11 @@ class PortAssigners {
                 PortAssigner.PortAssignment.DYNAMIC : PortAssigner.PortAssignment.STATIC;
     }
 
+    static PortAssigner.PortAssignment portAssignmentFrom(StartupLockConfiguration startupLockConfig) {
+        return startupLockConfig.isUseDynamicPorts() ?
+                PortAssigner.PortAssignment.DYNAMIC : PortAssigner.PortAssignment.STATIC;
+    }
+
     static AllowablePortRange allowablePortRangeFrom(DynamicPortsConfiguration dynamicPortsConfig) {
         return new AllowablePortRange(dynamicPortsConfig.getMinDynamicPort(), dynamicPortsConfig.getMaxDynamicPort());
     }

--- a/src/main/java/org/kiwiproject/dropwizard/util/bundle/StartupLockBundle.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/bundle/StartupLockBundle.java
@@ -1,0 +1,114 @@
+package org.kiwiproject.dropwizard.util.bundle;
+
+import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
+import static org.kiwiproject.dropwizard.util.bundle.PortAssigners.portAssignmentFrom;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.dropwizard.core.Configuration;
+import io.dropwizard.core.ConfiguredBundle;
+import io.dropwizard.core.setup.Environment;
+import lombok.extern.slf4j.Slf4j;
+import org.kiwiproject.curator.CuratorFrameworkHelper;
+import org.kiwiproject.curator.CuratorLockHelper;
+import org.kiwiproject.curator.zookeeper.ZooKeeperAvailabilityChecker;
+import org.kiwiproject.dropwizard.util.startup.StartupLocker;
+import org.kiwiproject.dropwizard.util.startup.SystemExecutioner;
+
+import java.net.InetAddress;
+import java.nio.file.Paths;
+
+/**
+ * Dropwizard bundle that acquires a distributed ZooKeeper lock during application initialization.
+ * <p>
+ * This bundle should be registered before any other bundles that require exclusive acess when starting.
+ * In other words, using this bundle ensures that only one Dropwizard application on a server can start
+ * while holding the lock.
+ * <p>
+ * The original use case for this bundle was to use it with {@link DynamicPortsBundle} to avoid
+ * port-in-use conflicts when starting several Dropwizard applications on a server simultaneously.
+ * In this use case, you first add this bundle, then the {@link DynamicPortsBundle} so that when
+ * dynamic ports are assigned, it is guaranteed another Dropwizard application won't attempt to
+ * use the same port. This matters mainly when the port range in which applications can use is
+ * constrained to a relatively small range.
+ * <p>
+ * The original need to lock around dynamic port assignment is also the reason why
+ * {@link StartupLockConfiguration} has a {@code useDynamicPorts} property, which is
+ * then provided to {@link StartupLocker}. In a future release, we may begin to decouple
+ * dynamic port assignment and this startup lock, for example by providing a way that
+ * users can specify whether the lock should be attempted or not via a boolean property
+ * or function. The decoupling would also apply to {@link StartupLocker} so that the
+ * boolean property or function is provided instead of {@link PortAssignment} in
+ * the {@link StartupLocker#acquireStartupLock acquireStartupLock} method.
+ */
+@Slf4j
+public abstract class StartupLockBundle<C extends Configuration>
+        implements ConfiguredBundle<C>, StartupLockConfigured<C> {
+
+    @Override
+    public void run(C configuration, Environment environment) throws Exception {
+        LOG.trace("Running StartupLockBundle");
+
+        var startupLocker = buildStartupLocker();
+
+        var startupLockConfig = getStartupLockConfiguration(configuration);
+        var portAssignment = portAssignmentFrom(startupLockConfig);
+
+        var ip = requireNotNull(InetAddress.getLocalHost().getHostAddress(), "ip address must not be null");
+        var lockPath = Paths.get(startupLockConfig.getZkStartupLockPath(), ip).toString();
+
+        LOG.debug("Acquire startup lock with port assignment {} and lock path: {}", portAssignment, lockPath);
+
+        var lockInfo = startupLocker.acquireStartupLock(
+                lockPath,
+                startupLockConfig.getZkStartupLockTimeout(),
+                portAssignment,
+                startupLockConfig.getCuratorConfig(),
+                environment);
+
+        LOG.trace("Add fallback startup listener");
+        startupLocker.addFallbackJettyStartupLifeCycleListener(lockInfo, environment);
+
+        LOG.trace("Add listener to release startup lock after server started");
+        environment.lifecycle().addServerLifecycleListener(server -> {
+            LOG.debug("Releasing startup lock if present");
+            startupLocker.releaseStartupLockIfPresent(lockInfo);
+        });
+    }
+
+    /**
+     * The {@link SystemExecutioner} that will be passed to the {@link StartupLocker}
+     * and which will be used if there is an error that causes the bundle to
+     * terminate the application using {@link SystemExecutioner#exit()}.
+     *
+     * @return a new instance
+     * @see StartupLocker
+     */
+    public SystemExecutioner getExecutioner() {
+        return new SystemExecutioner();
+    }
+
+    @VisibleForTesting
+    StartupLocker buildStartupLocker() {
+        return StartupLocker.builder()
+                .curatorFrameworkHelper(getCuratorFrameworkHelper())
+                .curatorLockHelper(getCuratorLockHelper())
+                .zkAvailabilityChecker(getKeeperAvailabilityChecker())
+                .executioner(getExecutioner())
+                .build();
+    }
+
+    @VisibleForTesting
+    CuratorFrameworkHelper getCuratorFrameworkHelper() {
+        return new CuratorFrameworkHelper();
+    }
+
+    @VisibleForTesting
+    CuratorLockHelper getCuratorLockHelper() {
+        return new CuratorLockHelper();
+    }
+
+    @VisibleForTesting
+    ZooKeeperAvailabilityChecker getKeeperAvailabilityChecker() {
+        return new ZooKeeperAvailabilityChecker();
+    }
+}

--- a/src/main/java/org/kiwiproject/dropwizard/util/bundle/StartupLockConfiguration.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/bundle/StartupLockConfiguration.java
@@ -1,0 +1,104 @@
+package org.kiwiproject.dropwizard.util.bundle;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.requireNonNullElse;
+import static java.util.Objects.requireNonNullElseGet;
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.util.Duration;
+import io.dropwizard.validation.MinDuration;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.kiwiproject.curator.config.CuratorConfig;
+
+import java.beans.ConstructorProperties;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Configuration class for startup locks which is used by {@link StartupLockBundle}.
+ */
+@Data
+public class StartupLockConfiguration {
+
+    /**
+     * Default path for ZooKeeper startup locks.
+     */
+    @SuppressWarnings("java:S1075")
+    public static final String DEFAULT_ZK_STARTUP_LOCK_PATH = "/kiwi-startup-locks";
+
+    /**
+     * Default timeout for ZooKeeper startup locks.
+     */
+    public static final Duration DEFAULT_ZK_STARTUP_LOCK_TIMEOUT = Duration.minutes(1);
+
+    /**
+     * Whether ports are being assigned randomly during startup.
+     * <p>
+     * The default value is true.
+     * <p>
+     * When this is true, the lock will be attempted. When it is false,
+     * the lock will <em>not</em> be attempted.
+     * <p>
+     * Even if you are <em>not</em> using the {@link StartupLockBundle} in
+     * conjunction with dynamic ports, you can ensure the lock will be attempted
+     * by setting this property to true.
+     */
+    private boolean useDynamicPorts;
+
+    /**
+     * The base lock path for ZooKeeper startup locks. The IP address is appended dynamically at runtime.
+     * <p>
+     * The default value is {@link #DEFAULT_ZK_STARTUP_LOCK_PATH}.
+     */
+    @NotBlank
+    private String zkStartupLockPath;
+
+    /**
+     * The maximum time to wait on startup ZooKeeper lock acquisition before timing out.
+     * <p>
+     * The default value is {@link #DEFAULT_ZK_STARTUP_LOCK_TIMEOUT}.
+     */
+    @NotNull
+    @MinDuration(value = 1, unit = TimeUnit.SECONDS)
+    private Duration zkStartupLockTimeout;
+
+    /**
+     * The configuration to use for Apache Curator, which is used to acquire the lock.
+     * <p>
+     * The default value is an instance created using the no-args constructor,
+     * which will result in the ZooKeeper conection string {@code "localhost:2181"}.
+     * This only makes sense if you are using a single-node ZooKeeper "cluster"
+     * on each server where your Dropwizard applications run, otherwise you should
+     * provide a ZooKeeper connection string to a real cluster (ensemble).
+     */
+    @NotNull
+    @Valid
+    @JsonProperty("curator")
+    private CuratorConfig curatorConfig;
+
+    public StartupLockConfiguration() {
+        this(null, null, null, null);
+    }
+
+    @Builder
+    @ConstructorProperties({ "useDynamicPorts", "zkStartupLockPath", "zkStartupLockTimeout", "curatorConfig" })
+    public StartupLockConfiguration(Boolean useDynamicPorts,
+                                    String zkStartupLockPath,
+                                    Duration zkStartupLockTimeout,
+                                    CuratorConfig curatorConfig) {
+
+        this.useDynamicPorts = toBooleanOrTrue(useDynamicPorts);
+        this.zkStartupLockPath = defaultIfBlank(zkStartupLockPath, DEFAULT_ZK_STARTUP_LOCK_PATH);
+        this.zkStartupLockTimeout = requireNonNullElse(zkStartupLockTimeout, DEFAULT_ZK_STARTUP_LOCK_TIMEOUT);
+        this.curatorConfig = requireNonNullElseGet(curatorConfig, CuratorConfig::new);
+    }
+
+    private static boolean toBooleanOrTrue(@Nullable Boolean booleanObject) {
+        return isNull(booleanObject) ? true : booleanObject.booleanValue();
+    }
+}

--- a/src/main/java/org/kiwiproject/dropwizard/util/bundle/StartupLockConfigured.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/bundle/StartupLockConfigured.java
@@ -1,0 +1,9 @@
+package org.kiwiproject.dropwizard.util.bundle;
+
+/**
+ * Defines how {@link StartupLockBundle} gets a {@link StartupLockConfiguration}
+ * from a Dropwizard Configuration.
+ */
+public interface StartupLockConfigured<C> {
+    StartupLockConfiguration getStartupLockConfiguration(C configuration);
+}

--- a/src/test/java/org/kiwiproject/dropwizard/util/bundle/MyStartupLockApp.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/bundle/MyStartupLockApp.java
@@ -1,0 +1,72 @@
+package org.kiwiproject.dropwizard.util.bundle;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.dropwizard.core.Application;
+import io.dropwizard.core.setup.Bootstrap;
+import io.dropwizard.core.setup.Environment;
+import io.dropwizard.util.Duration;
+import lombok.Getter;
+import org.kiwiproject.curator.config.CuratorConfig;
+import org.kiwiproject.dropwizard.util.startup.ExecutionStrategies;
+import org.kiwiproject.dropwizard.util.startup.PortAssigner;
+import org.kiwiproject.dropwizard.util.startup.StartupLockInfo;
+import org.kiwiproject.dropwizard.util.startup.StartupLocker;
+import org.kiwiproject.dropwizard.util.startup.SystemExecutioner;
+
+public class MyStartupLockApp extends Application<MyStartupLockConfig> {
+
+    @Getter
+    final ExecutionStrategies.ExitFlaggingExecutionStrategy executionStrategy =
+            (ExecutionStrategies.ExitFlaggingExecutionStrategy) ExecutionStrategies.exitFlagging();
+
+    @Getter
+    final SystemExecutioner systemExecutioner = new SystemExecutioner(executionStrategy);
+
+    @Getter
+    StartupLocker startupLocker;
+
+    public MyStartupLockApp() {
+        startupLocker = mock(StartupLocker.class);
+
+        when(startupLocker.acquireStartupLock(
+                anyString(),
+                any(Duration.class),
+                any(PortAssigner.PortAssignment.class),
+                any(CuratorConfig.class),
+                any(Environment.class)))
+                .thenReturn(mock(StartupLockInfo.class));
+    }
+
+    @Override
+    public void initialize(Bootstrap<MyStartupLockConfig> bootstrap) {
+        var startupLockBundle = new StartupLockBundle<MyStartupLockConfig>() {
+            @Override
+            public StartupLockConfiguration getStartupLockConfiguration(MyStartupLockConfig configuration) {
+                return StartupLockConfiguration.builder()
+                        .useDynamicPorts(configuration.isUseDynamicPorts())
+                        .zkStartupLockPath(configuration.getZkStartupLockPath())
+                        .build();
+            }
+
+            @Override
+            public SystemExecutioner getExecutioner() {
+                return systemExecutioner;
+            }
+
+            @Override
+            StartupLocker buildStartupLocker() {
+                return startupLocker;
+            }
+        };
+
+        bootstrap.addBundle(startupLockBundle);
+    }
+
+    @Override
+    public void run(MyStartupLockConfig configuration, Environment environment) {
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/util/bundle/MyStartupLockConfig.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/bundle/MyStartupLockConfig.java
@@ -1,0 +1,20 @@
+package org.kiwiproject.dropwizard.util.bundle;
+
+import io.dropwizard.core.Configuration;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.With;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MyStartupLockConfig extends Configuration {
+
+    @With
+    private boolean useDynamicPorts = true;
+
+    private String zkStartupLockPath = "/kiwi/service/startup-locks";
+}

--- a/src/test/java/org/kiwiproject/dropwizard/util/bundle/PortAssignersTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/bundle/PortAssignersTest.java
@@ -16,10 +16,26 @@ class PortAssignersTest {
         true, DYNAMIC
         false, STATIC
         """)
-    void shouldCreatePortAssignment(boolean useDynamicPorts,
-                                    PortAssigner.PortAssignment expectedPortAssignment) {
+    void shouldCreatePortAssignmentFromDynamicPortsConfiguration(boolean useDynamicPorts,
+                                                                 PortAssigner.PortAssignment expectedPortAssignment) {
 
         var dynamicPortsConfig = DynamicPortsConfiguration.builder()
+                .useDynamicPorts(useDynamicPorts)
+                .build();
+
+        assertThat(PortAssigners.portAssignmentFrom(dynamicPortsConfig))
+                .isEqualTo(expectedPortAssignment);
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+        true, DYNAMIC
+        false, STATIC
+        """)
+    void shouldCreatePortAssignmentFromStartupLockConfiguration(boolean useDynamicPorts,
+                                                                PortAssigner.PortAssignment expectedPortAssignment) {
+
+        var dynamicPortsConfig = StartupLockConfiguration.builder()
                 .useDynamicPorts(useDynamicPorts)
                 .build();
 

--- a/src/test/java/org/kiwiproject/dropwizard/util/bundle/StartupLockBundleTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/bundle/StartupLockBundleTest.java
@@ -1,0 +1,98 @@
+package org.kiwiproject.dropwizard.util.bundle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import io.dropwizard.util.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kiwiproject.curator.config.CuratorConfig;
+import org.kiwiproject.dropwizard.util.startup.PortAssigner;
+import org.kiwiproject.dropwizard.util.startup.StartupLockInfo;
+import org.kiwiproject.dropwizard.util.startup.SystemExecutioner;
+import org.kiwiproject.dropwizard.util.startup.ExecutionStrategies.SystemExitExecutionStrategy;
+import org.mockito.ArgumentCaptor;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+@DisplayName("StartupLockBundle")
+@ExtendWith(DropwizardExtensionsSupport.class)
+class StartupLockBundleTest {
+
+    static final DropwizardAppExtension<MyStartupLockConfig> APP =
+            new DropwizardAppExtension<>(MyStartupLockApp.class);
+
+    @Test
+    void shouldLockAndUnlock() throws UnknownHostException {
+        var application = (MyStartupLockApp) APP.getApplication();
+        var startupLockerMock = application.getStartupLocker();
+
+        var expectedLockPath = "/kiwi/service/startup-locks/" + InetAddress.getLocalHost().getHostAddress();
+
+        var inOrder = inOrder(startupLockerMock);
+
+        inOrder.verify(startupLockerMock).acquireStartupLock(
+            eq(expectedLockPath),
+            eq(Duration.minutes(1)),
+            eq(PortAssigner.PortAssignment.DYNAMIC),
+            any(CuratorConfig.class),
+            same(APP.getEnvironment())
+        );
+
+        var startupLockInfoCaptor1 = ArgumentCaptor.forClass(StartupLockInfo.class);
+        inOrder.verify(startupLockerMock)
+                .addFallbackJettyStartupLifeCycleListener(startupLockInfoCaptor1.capture(), same(APP.getEnvironment()));
+
+        var startupLockInfoCaptor2 = ArgumentCaptor.forClass(StartupLockInfo.class);
+        inOrder.verify(startupLockerMock)
+                .releaseStartupLockIfPresent(startupLockInfoCaptor2.capture());
+
+        assertThat(startupLockInfoCaptor1.getValue())
+                .describedAs("same StartupLockInfo should be used in fallback listenr and release")
+                .isSameAs(startupLockInfoCaptor2.getValue());
+
+        verifyNoMoreInteractions(startupLockerMock);
+    }
+
+    @Test
+    void shouldBuildStartupLocker() {
+        var startupLockBundle = new StartupLockBundle<MyStartupLockConfig>() {
+            @Override
+            public StartupLockConfiguration getStartupLockConfiguration(MyStartupLockConfig configuration) {
+                return StartupLockConfiguration.builder()
+                        .useDynamicPorts(configuration.isUseDynamicPorts())
+                        .zkStartupLockPath(configuration.getZkStartupLockPath())
+                        .build();
+            }
+        };
+
+        var startupLocker = startupLockBundle.buildStartupLocker();
+        assertThat(startupLocker).isNotNull();
+    }
+
+    @Test
+    void shouldProvideDefaultSystemExecutioner() {
+        var startupLockBundle = new StartupLockBundle<MyStartupLockConfig>() {
+            @Override
+            public StartupLockConfiguration getStartupLockConfiguration(MyStartupLockConfig configuration) {
+                return StartupLockConfiguration.builder()
+                        .useDynamicPorts(configuration.isUseDynamicPorts())
+                        .zkStartupLockPath(configuration.getZkStartupLockPath())
+                        .build();
+            }
+        };
+
+        assertThat(startupLockBundle.getExecutioner())
+                .isInstanceOf(SystemExecutioner.class)
+                .extracting(SystemExecutioner::getExecutionStrategy)
+                .isInstanceOf(SystemExitExecutionStrategy.class);
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/util/bundle/StartupLockConfigurationTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/bundle/StartupLockConfigurationTest.java
@@ -1,0 +1,101 @@
+package org.kiwiproject.dropwizard.util.bundle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.core.Configuration;
+import io.dropwizard.util.Duration;
+import lombok.Getter;
+import lombok.Setter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.test.util.Fixtures;
+import org.kiwiproject.yaml.YamlHelper;
+
+@DisplayName("StartupLockConfiguration")
+class StartupLockConfigurationTest {
+
+    @Test
+    void shouldHaveDefaults_WithNoArgsConstructor() {
+        var startupLockConfig = new StartupLockConfiguration();
+        assertDefaultValues(startupLockConfig);
+    }
+
+    @Test
+    void shouldHaveDefaults_WithBuilder() {
+        var startupLockConfig = StartupLockConfiguration.builder().build();
+        assertDefaultValues(startupLockConfig);
+    }
+
+    @Test
+    void shouldHaveDefaults_WithAllArgsConstructor() {
+        var startupLockConfig = new StartupLockConfiguration(null, null, null, null);
+        assertDefaultValues(startupLockConfig);
+    }
+
+    @Test
+    void shouldHaveDefaults_WhenDeserializeFromYaml_WhenNoLockConfigurationSpecified() {
+        var configuration = readMyConfig("StartupLockConfigurationTest/startup-lock-config-none.yml");
+
+        var startupLockConfig = configuration.getStartupLockConfiguration();
+        assertDefaultValues(startupLockConfig);
+    }
+
+    private static void assertDefaultValues(StartupLockConfiguration startupLockConfig) {
+        assertAll(
+            () -> assertThat(startupLockConfig.isUseDynamicPorts()).isTrue(),
+            () -> assertThat(startupLockConfig.getZkStartupLockPath()).isEqualTo("/kiwi-startup-locks"),
+            () -> assertThat(startupLockConfig.getZkStartupLockTimeout()).isEqualTo(Duration.minutes(1)),
+            () -> assertThat(startupLockConfig.getCuratorConfig()).isNotNull()
+        );
+    }
+
+    @Test
+    void shouldAcceptSomeValues_WhenDeserializeFromYaml() {
+        var configuration = readMyConfig("StartupLockConfigurationTest/startup-lock-config-some-properties.yml");
+
+        var startupLockConfig = configuration.getStartupLockConfiguration();
+        assertAll(
+            () -> assertThat(startupLockConfig.isUseDynamicPorts()).isTrue(),
+            () -> assertThat(startupLockConfig.getZkStartupLockPath()).isEqualTo("/service/startup-locks"),
+            () -> assertThat(startupLockConfig.getZkStartupLockTimeout()).isEqualTo(Duration.seconds(5)),
+            () -> assertThat(startupLockConfig.getCuratorConfig()).isNotNull()
+        );
+    }
+
+    @Test
+    void shouldAcceptAllValues_WhenDeserializeFromYaml() {
+        var configuration = readMyConfig("StartupLockConfigurationTest/startup-lock-config-all-properties.yml");
+
+        var startupLockConfig = configuration.getStartupLockConfiguration();
+        assertAll(
+            () -> assertThat(startupLockConfig.isUseDynamicPorts()).isFalse(),
+            () -> assertThat(startupLockConfig.getZkStartupLockPath()).isEqualTo("/service/startup/locks"),
+            () -> assertThat(startupLockConfig.getZkStartupLockTimeout()).isEqualTo(Duration.seconds(45)),
+            () -> assertThat(startupLockConfig.getCuratorConfig())
+                    .isNotNull()
+                    .extracting("zkConnectString", "sessionTimeout")
+                    .containsExactly(
+                        "zk1.test.acme.com:2181,zk2.test.acme.com:2181,zk3.test.acme.com:2181",
+                        Duration.seconds(30)
+                    )
+        );
+    }
+
+    private static MyConfig readMyConfig(String resourceName) {
+        var yaml = Fixtures.fixture(resourceName);
+
+        var yamlHelper = new YamlHelper();
+        return yamlHelper.toObject(yaml, MyConfig.class);
+    }
+
+    @Getter
+    @Setter
+    public static class MyConfig extends Configuration {
+        private String name;
+
+        @JsonProperty("startupLock")
+        private StartupLockConfiguration startupLockConfiguration = new StartupLockConfiguration();
+    }
+}

--- a/src/test/resources/StartupLockConfigurationTest/startup-lock-config-all-properties.yml
+++ b/src/test/resources/StartupLockConfigurationTest/startup-lock-config-all-properties.yml
@@ -1,0 +1,10 @@
+---
+name: My Test App
+
+startupLock:
+  useDynamicPorts: false
+  zkStartupLockPath: /service/startup/locks
+  zkStartupLockTimeout: 45 seconds
+  curator:
+    zkConnectString: zk1.test.acme.com:2181,zk2.test.acme.com:2181,zk3.test.acme.com:2181
+    sessionTimeout: 30 seconds

--- a/src/test/resources/StartupLockConfigurationTest/startup-lock-config-none.yml
+++ b/src/test/resources/StartupLockConfigurationTest/startup-lock-config-none.yml
@@ -1,0 +1,2 @@
+---
+name: My Test App

--- a/src/test/resources/StartupLockConfigurationTest/startup-lock-config-some-properties.yml
+++ b/src/test/resources/StartupLockConfigurationTest/startup-lock-config-some-properties.yml
@@ -1,0 +1,6 @@
+---
+name: My Test App
+
+startupLock:
+  zkStartupLockPath: /service/startup-locks
+  zkStartupLockTimeout: 5 seconds


### PR DESCRIPTION
* Add StartupLockConfiguration, which contains startup lock configuration
* Add StartupLockConfigured interface, which defines how the bundle gets the configuration
* Add StartupLockBundle, which acquires a distributed ZooKeeper lock during startup
* Add overloaded portAssignmentFrom to PortAssigners ; it accepts a StartupLockConfiguration

Closes #460