### PR TITLE
Factory/conversion methods in PortAssigner enums

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/bundle/PortAssigners.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/bundle/PortAssigners.java
@@ -4,18 +4,18 @@ import lombok.experimental.UtilityClass;
 
 import org.kiwiproject.dropwizard.util.startup.AllowablePortRange;
 import org.kiwiproject.dropwizard.util.startup.PortAssigner;
+import org.kiwiproject.dropwizard.util.startup.PortAssigner.PortAssignment;
+import org.kiwiproject.dropwizard.util.startup.PortAssigner.PortSecurity;
 
 @UtilityClass
 class PortAssigners {
 
-    static PortAssigner.PortAssignment portAssignmentFrom(DynamicPortsConfiguration dynamicPortsConfig) {
-        return dynamicPortsConfig.isUseDynamicPorts() ?
-                PortAssigner.PortAssignment.DYNAMIC : PortAssigner.PortAssignment.STATIC;
+    static PortAssignment portAssignmentFrom(DynamicPortsConfiguration dynamicPortsConfig) {
+        return PortAssignment.fromBooleanDynamicWhenTrue(dynamicPortsConfig.isUseDynamicPorts());
     }
 
-    static PortAssigner.PortAssignment portAssignmentFrom(StartupLockConfiguration startupLockConfig) {
-        return startupLockConfig.isUseDynamicPorts() ?
-                PortAssigner.PortAssignment.DYNAMIC : PortAssigner.PortAssignment.STATIC;
+    static PortAssignment portAssignmentFrom(StartupLockConfiguration startupLockConfig) {
+        return PortAssignment.fromBooleanDynamicWhenTrue(startupLockConfig.isUseDynamicPorts());
     }
 
     static AllowablePortRange allowablePortRangeFrom(DynamicPortsConfiguration dynamicPortsConfig) {
@@ -23,7 +23,6 @@ class PortAssigners {
     }
 
     static PortAssigner.PortSecurity portSecurityFrom(DynamicPortsConfiguration dynamicPortsConfig) {
-        return dynamicPortsConfig.isUseSecureDynamicPorts() ?
-                PortAssigner.PortSecurity.SECURE : PortAssigner.PortSecurity.NON_SECURE;
+        return PortSecurity.fromBooleanSecureWhenTrue(dynamicPortsConfig.isUseSecureDynamicPorts());
     }
 }

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/PortAssigner.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/PortAssigner.java
@@ -1,6 +1,7 @@
 package org.kiwiproject.dropwizard.util.startup;
 
 import static java.util.Objects.isNull;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
 import static org.kiwiproject.base.KiwiStrings.format;
 import static org.kiwiproject.collect.KiwiLists.first;
@@ -50,12 +51,58 @@ import java.util.stream.IntStream;
 @Getter(AccessLevel.PACKAGE) // For testing
 public class PortAssigner {
 
+    /**
+     * An enum that represents static or dynamic port assignment.
+     */
     public enum PortAssignment {
-        STATIC, DYNAMIC
+        STATIC, DYNAMIC;
+
+        /**
+         * Return {@link #DYNAMIC} when the given value is true, otherwise {@link #STATIC}.
+         *
+         * @param value the boolean value to convert
+         * @return the equivalent {@link PortAssignment} instance
+         */
+        public static PortAssignment fromBooleanDynamicWhenTrue(boolean value) {
+            return value ? DYNAMIC : STATIC;
+        }
     }
 
+    /**
+     * An enum that represents whether a port is secure (HTTPS) or not secure (HTTP).
+     */
     public enum PortSecurity {
-        SECURE, NON_SECURE
+        SECURE, NON_SECURE;
+
+        /**
+         * Return {@link #SECURE} when the given value is true, otherwise {@link #NON_SECURE}.
+         *
+         * @param value the boolean value to convert
+         * @return the equivalent {@link PortSecurity} instance
+         */
+        public static PortSecurity fromBooleanSecureWhenTrue(boolean value) {
+            return value ? SECURE : NON_SECURE;
+        }
+
+        /**
+         * Return the instance of this enum which is equivalent to the given {@link Port.Security}.
+         *
+         * @param security the {@link Port.Security} value to convert
+         * @return
+         */
+        public static PortSecurity fromSecurity(Port.Security security) {
+            checkArgumentNotNull(security, "security must not be null");
+            return (security == Port.Security.SECURE) ? SECURE : NON_SECURE;
+        }
+
+        /**
+         * Convert this instance to a {@link Port.Security} instance.
+         *
+         * @return the equivalent {@link Port.Security} instance
+         */
+        public Port.Security toSecurity() {
+            return (this == PortSecurity.SECURE) ? Port.Security.SECURE : Port.Security.NOT_SECURE;
+        }
     }
 
     private final LocalPortChecker localPortChecker;


### PR DESCRIPTION
* Add factory method to create PortAssigner.PortAssignment from a boolean
* Add factory method to create PortAssigner.PortSecurity from a boolean
* Add methods to convert between PortAssigner.PortSecurity and Port.Security

Closes #463
Closes #464
Closes #465