### PR TITLE
Misc code cleanup

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/bundle/DynamicPortsConfiguration.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/bundle/DynamicPortsConfiguration.java
@@ -1,20 +1,18 @@
 package org.kiwiproject.dropwizard.util.bundle;
 
-import static java.util.Objects.isNull;
+import static org.kiwiproject.base.KiwiBooleans.toBooleanOrTrue;
+import static org.kiwiproject.base.KiwiIntegers.toIntOrDefault;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Positive;
 import lombok.Builder;
 import lombok.Data;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.kiwiproject.config.TlsContextConfiguration;
 
 import java.beans.ConstructorProperties;
-
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Positive;
 
 /**
  * Configuration class for dynamic ports used by {@link DynamicPortsBundle}.
@@ -91,11 +89,4 @@ public class DynamicPortsConfiguration {
         this.tlsContextConfiguration = tlsContextConfiguration;
     }
 
-    private static boolean toBooleanOrTrue(@Nullable Boolean booleanObject) {
-        return isNull(booleanObject) ? true : booleanObject.booleanValue();
-    }
-
-    private static int toIntOrDefault(@Nullable Integer integerObject, int defaultValue) {
-        return isNull(integerObject) ? defaultValue : integerObject.intValue();
-    }
 }

--- a/src/main/java/org/kiwiproject/dropwizard/util/bundle/StartupLockConfiguration.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/bundle/StartupLockConfiguration.java
@@ -1,9 +1,9 @@
 package org.kiwiproject.dropwizard.util.bundle;
 
-import static java.util.Objects.isNull;
 import static java.util.Objects.requireNonNullElse;
 import static java.util.Objects.requireNonNullElseGet;
 import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
+import static org.kiwiproject.base.KiwiBooleans.toBooleanOrTrue;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.util.Duration;
@@ -13,7 +13,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.kiwiproject.curator.config.CuratorConfig;
 
 import java.beans.ConstructorProperties;
@@ -63,6 +62,7 @@ public class StartupLockConfiguration {
      * <p>
      * The default value is {@link #DEFAULT_ZK_STARTUP_LOCK_TIMEOUT}.
      */
+    @SuppressWarnings("DefaultAnnotationParam")
     @NotNull
     @MinDuration(value = 1, unit = TimeUnit.SECONDS)
     private Duration zkStartupLockTimeout;
@@ -98,7 +98,4 @@ public class StartupLockConfiguration {
         this.curatorConfig = requireNonNullElseGet(curatorConfig, CuratorConfig::new);
     }
 
-    private static boolean toBooleanOrTrue(@Nullable Boolean booleanObject) {
-        return isNull(booleanObject) ? true : booleanObject.booleanValue();
-    }
 }

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/PortAssigner.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/PortAssigner.java
@@ -88,7 +88,7 @@ public class PortAssigner {
          * Return the instance of this enum which is equivalent to the given {@link Port.Security}.
          *
          * @param security the {@link Port.Security} value to convert
-         * @return
+         * @return the equivalent {@link PortSecurity} instance
          */
         public static PortSecurity fromSecurity(Port.Security security) {
             checkArgumentNotNull(security, "security must not be null");

--- a/src/test/java/org/kiwiproject/dropwizard/util/bundle/MyStartupLockApp.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/bundle/MyStartupLockApp.java
@@ -20,14 +20,13 @@ import org.kiwiproject.dropwizard.util.startup.SystemExecutioner;
 public class MyStartupLockApp extends Application<MyStartupLockConfig> {
 
     @Getter
-    final ExecutionStrategies.ExitFlaggingExecutionStrategy executionStrategy =
-            (ExecutionStrategies.ExitFlaggingExecutionStrategy) ExecutionStrategies.exitFlagging();
+    final ExecutionStrategies.ExitFlaggingExecutionStrategy executionStrategy = ExecutionStrategies.exitFlagging();
 
     @Getter
     final SystemExecutioner systemExecutioner = new SystemExecutioner(executionStrategy);
 
     @Getter
-    StartupLocker startupLocker;
+    final StartupLocker startupLocker;
 
     public MyStartupLockApp() {
         startupLocker = mock(StartupLocker.class);

--- a/src/test/java/org/kiwiproject/dropwizard/util/job/JobErrorHandlersTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/job/JobErrorHandlersTest.java
@@ -24,10 +24,7 @@ class JobErrorHandlersTest {
     void shouldCreateLoggingHandler() {
         var handler = JobErrorHandlers.loggingHandler();
 
-        var job = MonitoredJob.builder()
-                .name("test task")
-                .task(() -> LOG.info("Executing task"))
-                .build();
+        var job = newTestJob();
 
         assertThatCode(() -> handler.handle(job, new RuntimeException("an oop happened")))
                 .doesNotThrowAnyException();
@@ -38,15 +35,19 @@ class JobErrorHandlersTest {
         var logger = mock(Logger.class);
         var handler = JobErrorHandlers.loggingHandler(logger);
 
-        var job = MonitoredJob.builder()
-                .name("test task")
-                .task(() -> LOG.info("Executing task"))
-                .build();
+        var job = newTestJob();
 
         var exception = new RuntimeException("an oop happened");
         assertThatCode(() -> handler.handle(job, exception))
                 .doesNotThrowAnyException();
 
         verify(logger).warn("Job '{}' threw an exception", "test task", exception);
+    }
+
+    private static MonitoredJob newTestJob() {
+        return MonitoredJob.builder()
+                .name("test task")
+                .task(() -> LOG.info("Executing task"))
+                .build();
     }
 }


### PR DESCRIPTION
* Organize imports in several classes.
* Replace custom methods with new utilities from kiwi in DynamicPortsConfiguration and StartupLockConfiguration.
* Fix missing return javadoc tag in PortAssigner.
* Remove (now) redundant cast in MyStartupLockApp.
* Make StartupLocker field final in MyStartupLockApp.
* Extract duplicate code in JobErrorHandlersTest into method.