### PR TITLE
Sonar cleanup: StandardExceptionMappersTest

### DIFF
--- a/src/test/java/org/kiwiproject/dropwizard/util/exception/StandardExceptionMappersTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/exception/StandardExceptionMappersTest.java
@@ -164,6 +164,7 @@ class StandardExceptionMappersTest {
 
         boolean registerDefaultExceptionMappersCalled;
 
+        @SuppressWarnings("unused")  // there is nothing to do with the parameter, but it must exist
         public void setRegisterDefaultExceptionMappers(boolean registerDefaultExceptionMappers) {
             registerDefaultExceptionMappersCalled = true;
         }


### PR DESCRIPTION
Add "unused" warning suppression annotation to a parameter which must exist for the test, but we don't need to do anything with.