### PR TITLE
Misc code cleanup in health checks

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/health/CachingHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/CachingHealthCheck.java
@@ -8,7 +8,6 @@ import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-
 import lombok.Getter;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
@@ -23,7 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * A {@link HealthCheck} that caches the result of another HealthCheck
  * for a certain period of time.
  * <p>
- * Use this if a HealthCheck is expensive to compute and you want to minimize
+ * Use this if a HealthCheck is expensive to compute, and you want to minimize
  * the execution cost. For example, a HealthCheck that makes network calls might
  * be a good candidate for caching if health checks are executed frequently.
  */
@@ -42,7 +41,7 @@ public class CachingHealthCheck extends HealthCheck {
      * A name for this CachingHealthCheck.
      * <p>
      * Usually this should be the name given to the wrapped HealthCheck
-     * so that it can be easily distingushed from others.
+     * so that it can be easily distinguished from others.
      */
     @Getter
     @Accessors(fluent = true)
@@ -168,7 +167,7 @@ public class CachingHealthCheck extends HealthCheck {
     }
 
     private TimestampedResult executeHealthCheck() {
-        // The default HealhCheck#execute implementation catches Exception, but it
+        // The default HealthCheck#execute implementation catches Exception, but it
         // is not final and can therefore be overridden. So, we will be conservative
         // and assume an Exception could be thrown in a subclass.
 

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/UrlHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/UrlHealthCheck.java
@@ -1,6 +1,6 @@
 package org.kiwiproject.dropwizard.util.health;
 
-import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import static org.kiwiproject.base.KiwiPreconditions.requireNotBlank;
 import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
 import static org.kiwiproject.jaxrs.KiwiResponses.successfulAlwaysClosing;
@@ -9,7 +9,6 @@ import static org.kiwiproject.metrics.health.HealthCheckResults.newUnhealthyResu
 
 import com.codahale.metrics.health.HealthCheck;
 import com.google.common.annotations.VisibleForTesting;
-
 import jakarta.ws.rs.client.Client;
 import lombok.extern.slf4j.Slf4j;
 import org.kiwiproject.base.DefaultEnvironment;
@@ -55,7 +54,7 @@ public class UrlHealthCheck extends HealthCheck {
      * {@code true}.
      * <p>
      * This is useful when there are multiple instances of a service, and you only want
-     * one of them to execute the health check, for example the "leader" when using a
+     * one of them to execute the health check, for example, the "leader" when using a
      * "Leader Latch" pattern.
      *
      * @param client the HTTP client to use when connecting to the URL
@@ -108,7 +107,7 @@ public class UrlHealthCheck extends HealthCheck {
     private boolean shouldExecute() {
         try {
             var result = executionCondition.get();
-            return isNull(result) ? false : result;
+            return nonNull(result) && result;
         } catch (Exception e) {
             LOG.error("executionCondition threw an exception. Assuming the health check should execute.", e);
             return true;


### PR DESCRIPTION
* Fix a few grammatical and spelling errors in CachingHealthCheck
* Replace boolean literal in UrlHealthCheck#shouldExecute