### PR TITLE
Log JsonProcessingExceptions at WARN level by default

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/exception/JsonExceptionMappers.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/exception/JsonExceptionMappers.java
@@ -29,7 +29,7 @@ class JsonExceptionMappers {
                 LOG.error("Unable to deserialize the specific type", exception);
                 e = new JaxrsException(exception);
             } else {
-                LOG.debug(DEFAULT_MSG, exception);
+                LOG.warn(DEFAULT_MSG, exception);
                 e = new JaxrsBadRequestException(message, exception);
             }
         }


### PR DESCRIPTION
Log JsonProcessingExceptions that do not meet specific criteria for logging specialized messages at WARN or ERROR level, log them as a generic "Unable to process JSON" at WARN level instead of at DEBUG level. This can aid in debugging problems.

Closes #519