### PR TITLE
Replace deprecated API usage in UrlHealthCheckTest

### DIFF
--- a/src/test/java/org/kiwiproject/dropwizard/util/health/UrlHealthCheckTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/health/UrlHealthCheckTest.java
@@ -54,7 +54,7 @@ class UrlHealthCheckTest {
                 .hostnameVerifier(new NoopHostnameVerifier())
                 .build();
 
-        description = RandomStringUtils.randomAlphabetic(15);
+        description = RandomStringUtils.secure().nextAlphabetic(15);
         url = server.url(STATUS_PATH).toString();
         kiwiEnvironment = mock(KiwiEnvironment.class);
     }


### PR DESCRIPTION
* Replace RandomStringUtils.randomAlphabetic(...) with RandomStringUtils.secure().nextAlphabetic(...)