### PR TITLE
Fix Javadocs in AllowablePortRange and DynamicPortsConfiguration

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/bundle/DynamicPortsConfiguration.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/bundle/DynamicPortsConfiguration.java
@@ -50,7 +50,7 @@ public class DynamicPortsConfiguration {
     /**
      * The highest port that can be assigned when {@code useDynamicPorts} is enabled.
      * <p>
-     * The default value is 65353 (the highest available port).
+     * The default value is 65,355 (the highest available port).
      */
     @Positive
     @Max(DEFAULT_MAX_DYNAMIC_PORT)

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/AllowablePortRange.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/AllowablePortRange.java
@@ -23,9 +23,10 @@ public class AllowablePortRange {
     /**
      * Creates a new AllowablePortRange
      *
-     * @param minPortNumber The minimum port allowed in the range
-     * @param maxPortNumber The maximum port allowed in the range
-     * @throws IllegalStateException if the minPortNumber is greater than or equal to the maxPortNumber or if either port is not valid
+     * @param minPortNumber The minimum port allowed in the range (inclusive)
+     * @param maxPortNumber The maximum port allowed in the range (inclusive)
+     * @throws IllegalStateException if the minPortNumber is greater than or equal to the maxPortNumber,
+     * or if either port is not valid
      */
     public AllowablePortRange(int minPortNumber, int maxPortNumber) {
         checkState(minPortNumber < maxPortNumber,


### PR DESCRIPTION
* DynamicPortsConfiguration had an incorrect value in the Javadocs for the maximum port.
* Clarify that the AllowablePortRange uses inclusive min/max ports.