### PR TITLE
Introduce the ability to define custom port assignment

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/FreePortFinder.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/FreePortFinder.java
@@ -1,0 +1,30 @@
+package org.kiwiproject.dropwizard.util.startup;
+
+/**
+ * Defines a contract for finding application and admin ports for a service.
+ * <p>
+ * This is a {@link FunctionalInterface} so that it can be created with
+ * lambda expressions, method references, or constructor references.
+ */
+@FunctionalInterface
+public interface FreePortFinder {
+
+    /**
+     * Find application and admin ports.
+     *
+     * @param portRange the allowable port range
+     * @return a new {@link ServicePorts} instance
+     * @throws org.kiwiproject.dropwizard.util.exception.NoAvailablePortException if no open port was found
+     *                                                                            in the allowable port range
+     */
+    ServicePorts find(AllowablePortRange portRange);
+
+    /**
+     * A record that represents the application and admin ports for a Dropwizard application.
+     *
+     * @param applicationPort the application port
+     * @param adminPort       the admin port
+     */
+    record ServicePorts(int applicationPort, int adminPort) {
+    }
+}

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/RandomFreePortFinder.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/RandomFreePortFinder.java
@@ -1,0 +1,98 @@
+package org.kiwiproject.dropwizard.util.startup;
+
+import static java.util.Objects.isNull;
+import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
+import static org.kiwiproject.base.KiwiStrings.format;
+
+import lombok.extern.slf4j.Slf4j;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.kiwiproject.dropwizard.util.exception.NoAvailablePortException;
+import org.kiwiproject.net.LocalPortChecker;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.IntSupplier;
+import java.util.random.RandomGenerator;
+import java.util.stream.IntStream;
+
+/**
+ * Finds random application and admin ports in an {@link AllowablePortRange}.
+ */
+@Slf4j
+public class RandomFreePortFinder implements FreePortFinder {
+
+    private final LocalPortChecker localPortChecker;
+    private final RandomGenerator randomGenerator = RandomGenerator.getDefault();
+
+    /**
+     * Create a new instance.
+     */
+    public RandomFreePortFinder() {
+        this(new LocalPortChecker());
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param localPortChecker the port checker to use
+     */
+    public RandomFreePortFinder(LocalPortChecker localPortChecker) {
+        this.localPortChecker = requireNotNull(localPortChecker, "localPortChecker must not be null");
+    }
+
+    /**
+     * Find application and admin ports randomly.
+     * <p>
+     * If {@code portRange} is {@code null}, then the application and admin
+     * ports will both be zero. This will result in the ports being randomly
+     * selected.
+     * <p>
+     * This method only returns a {@link ServicePorts} instance when there two open
+     * ports in the range. Otherwise, it throws a {@link NoAvailablePortException}.
+     *
+     * @param portRange the allowable port range, or {@code null}
+     * @return a new {@link ServicePorts} instance
+     * @throws NoAvailablePortException if no open port was found in the allowable port range
+     */
+    @Override
+    public ServicePorts find(@Nullable AllowablePortRange portRange) {
+        if (isNull(portRange)) {
+            return new ServicePorts(0, 0);
+        }
+
+        var usedPorts = new HashSet<Integer>();
+        var applicationPort = findFreePort(portRange, usedPorts);
+        var adminPort = findFreePort(portRange, usedPorts);
+
+        return new ServicePorts(applicationPort, adminPort);
+    }
+
+    /**
+     * @implNote Mutates {@code usedPorts} for each used port it finds
+     */
+    private int findFreePort(AllowablePortRange portRange, Set<Integer> usedPorts) {
+        IntSupplier portSupplier = () -> portRange.getMinPortNumber() +
+                randomGenerator.nextInt(portRange.getNumPortsInRange());
+
+        var assignedPort = IntStream.generate(portSupplier)
+                .limit(portRange.getMaxPortCheckAttempts())
+                .filter(port -> availableAndUnused(port, usedPorts))
+                .findFirst();
+
+        if (assignedPort.isPresent()) {
+            usedPorts.add(assignedPort.getAsInt());
+            return assignedPort.getAsInt();
+        }
+
+        var message = format("Could not find an available port between {} and {} after {} attempts. I give up.",
+                portRange.getMinPortNumber(),
+                portRange.getMaxPortNumber(),
+                portRange.getMaxPortCheckAttempts());
+        throw new NoAvailablePortException(message);
+    }
+
+    private boolean availableAndUnused(int port, Set<Integer> usedPorts) {
+        LOG.trace("Checking if port {} is unused and available", port);
+        return !usedPorts.contains(port) && localPortChecker.isPortAvailable(port);
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/util/startup/RandomFreePortFinderTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/startup/RandomFreePortFinderTest.java
@@ -1,0 +1,122 @@
+package org.kiwiproject.dropwizard.util.startup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.dropwizard.util.exception.NoAvailablePortException;
+import org.kiwiproject.net.LocalPortChecker;
+
+@DisplayName("RandomFreePortFinder")
+class RandomFreePortFinderTest {
+
+    @RepeatedTest(10)
+    void shouldCreateRandomFreePortFinder() {
+        var portFinder = new RandomFreePortFinder();
+        var minPortNumber = 32_768;
+        var maxPortNumber = 49_151;
+        var range = new AllowablePortRange(minPortNumber, maxPortNumber);
+
+        var servicePorts = portFinder.find(range);
+
+        assertAll(
+                () -> assertThat(servicePorts.applicationPort()).isBetween(minPortNumber, maxPortNumber),
+                () -> assertThat(servicePorts.adminPort()).isBetween(minPortNumber, maxPortNumber),
+                () -> assertThat(servicePorts.applicationPort()).isNotEqualTo(servicePorts.adminPort())
+        );
+    }
+
+    @Test
+    void shouldRequireLocalPortChecker() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new RandomFreePortFinder(null))
+                .withMessage("localPortChecker must not be null");
+    }
+
+    @Test
+    void shouldReturnZeroPorts_WhenAllowablePortRangeIsNull() {
+        var checker = mock(LocalPortChecker.class);
+        var portFinder = new RandomFreePortFinder(checker);
+        var servicePorts = portFinder.find(null);
+
+        assertAll(
+                () -> assertThat(servicePorts.applicationPort()).isZero(),
+                () -> assertThat(servicePorts.adminPort()).isZero()
+        );
+
+        verifyNoInteractions(checker);
+    }
+
+    @RepeatedTest(25)
+    void shouldFindRandomAvailablePortsInAllowableRange() {
+        var minPortNumber = 9_000;
+        var maxPortNumber = 9_010;
+        var range = new AllowablePortRange(minPortNumber, maxPortNumber);
+        var checker = mock(LocalPortChecker.class);
+        when(checker.isPortAvailable(anyInt())).thenReturn(true);
+
+        var portFinder = new RandomFreePortFinder(checker);
+        var servicePorts = portFinder.find(range);
+
+        assertAll(
+                () -> assertThat(servicePorts.applicationPort()).isBetween(minPortNumber, maxPortNumber),
+                () -> assertThat(servicePorts.adminPort()).isBetween(minPortNumber, maxPortNumber),
+                () -> assertThat(servicePorts.applicationPort()).isNotEqualTo(servicePorts.adminPort())
+        );
+
+        verify(checker, times(2)).isPortAvailable(anyInt());
+    }
+
+    @RepeatedTest(10)
+    void shouldFindAvailablePortsAfterTheFirstFewAreNotOpen() {
+        var minPortNumber = 9_000;
+        var maxPortNumber = 9_002;
+        var range = new AllowablePortRange(minPortNumber, maxPortNumber);
+        var checker = mock(LocalPortChecker.class);
+        when(checker.isPortAvailable(anyInt()))
+                .thenReturn(false)
+                .thenReturn(false)
+                .thenReturn(false)
+                .thenReturn(true)
+                .thenReturn(true);
+
+        var portFinder = new RandomFreePortFinder(checker);
+        var servicePorts = portFinder.find(range);
+
+        assertAll(
+                () -> assertThat(servicePorts.applicationPort()).isBetween(minPortNumber, maxPortNumber),
+                () -> assertThat(servicePorts.adminPort()).isBetween(minPortNumber, maxPortNumber),
+                () -> assertThat(servicePorts.applicationPort()).isNotEqualTo(servicePorts.adminPort())
+        );
+
+        verify(checker, times(5)).isPortAvailable(anyInt());
+    }
+
+    @Test
+    void shouldThrowNoAvailablePortException_WhenNoPortsCanBeFound() {
+        var minPortNumber = 9_000;
+        var maxPortNumber = 9_001;
+        var range = new AllowablePortRange(minPortNumber, maxPortNumber);
+        var checker = mock(LocalPortChecker.class);
+        when(checker.isPortAvailable(anyInt())).thenReturn(false);
+
+        var portFinder = new RandomFreePortFinder(checker);
+
+        assertThatThrownBy(() -> portFinder.find(range))
+                .isInstanceOf(NoAvailablePortException.class)
+                .hasMessage("Could not find an available port between %d and %d after 6 attempts. I give up.",
+                        minPortNumber, maxPortNumber);
+
+        verify(checker, times(6)).isPortAvailable(anyInt());
+    }
+}


### PR DESCRIPTION
* Add FreePortFinder as a generic port assignment strategy
* Add RandomFreePortFinder as the default strategy, which is consistent with the current behavior of this library.
* Modify PortAssigner to accept a FreePortFinder and use it to get the application and admin ports. If not specified, it will use RandomFreePortFinder as the port assignment strategy.

Closes #536