### PR TITLE
Add incremental and adjacent implementations of FreePortFinder

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/AdjacentFreePortFinder.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/AdjacentFreePortFinder.java
@@ -1,0 +1,98 @@
+package org.kiwiproject.dropwizard.util.startup;
+
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
+import static org.kiwiproject.base.KiwiStrings.f;
+
+import lombok.extern.slf4j.Slf4j;
+import org.kiwiproject.dropwizard.util.exception.NoAvailablePortException;
+import org.kiwiproject.net.LocalPortChecker;
+
+/**
+ * Finds application and admin ports in an {@link AllowablePortRange}
+ * by traversing through each port number sequentially, and ensuring
+ * that the ports are adjacent.
+ */
+@Slf4j
+public class AdjacentFreePortFinder implements FreePortFinder {
+
+    private final LocalPortChecker localPortChecker;
+
+    /**
+     * Create a new instance.
+     */
+    public AdjacentFreePortFinder() {
+        this(new LocalPortChecker());
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param localPortChecker the port checker to use
+     */
+    public AdjacentFreePortFinder(LocalPortChecker localPortChecker) {
+        this.localPortChecker = requireNotNull(localPortChecker, "localPortChecker must not be null");
+    }
+
+    /**
+     * Find the first two open and adjacent ports in the given port range, assigning them to
+     * the application and admin ports, respectively.
+     * <p>
+     * This method only returns a {@link ServicePorts} instance when there are adjacent ports
+     * in the port range. Otherwise, it throws a {@link NoAvailablePortException}.
+     *
+     * @param portRange the allowable port range
+     * @return a new {@link ServicePorts} instance
+     * @throws NoAvailablePortException if two open adjacent ports were not found in the allowable port range
+     */
+    @Override
+    public ServicePorts find(AllowablePortRange portRange) {
+        checkArgumentNotNull(portRange, "portRange must not be null");
+
+        var applicationPort = portRange.getMinPortNumber();
+        var maxApplicationPort = portRange.getMaxPortNumber();
+
+        while (applicationPort < maxApplicationPort) {
+            LOG.trace("At top of loop with applicationPort: {}", applicationPort);
+
+            // If the application port isn't open, skip the remaining admin port check
+            if (portIsNotOpen(applicationPort)) {
+                LOG.trace("applicationPort {} is not open, so increment it by one and continue", applicationPort);
+                ++applicationPort;
+                continue;
+            }
+
+            // The application port is available, so check if the next port is open.
+            // If it is, we've got two adjacent open ports and can stop checking.
+            var adminPort = applicationPort + 1;
+            if (portIsOpen(adminPort)) {
+                LOG.trace("applicationPort {} and adminPort {} are both open, so use them and return",
+                        applicationPort, adminPort);
+                return new ServicePorts(applicationPort, adminPort);
+            }
+
+            // Since the admin port was not open, set the next application port to
+            // the port following it to avoid checking the same (closed) port twice.
+            var originalApplicationPort = applicationPort;
+            applicationPort = adminPort + 1;
+            LOG.trace("applicationPort {} is open, but adminPort {} is not, so set applicationPort to {}",
+                    originalApplicationPort, adminPort, applicationPort);
+        }
+
+        LOG.trace("applicationPort {} is at the end of the port range, so there is no way to get an admin port",
+                applicationPort);
+
+        var message = f("Could not find two adjacent open ports between {} and {}",
+                portRange.getMinPortNumber(),
+                portRange.getMaxPortNumber());
+        throw new NoAvailablePortException(message);
+    }
+
+    private boolean portIsNotOpen(int port) {
+        return !portIsOpen(port);
+    }
+
+    private boolean portIsOpen(int port) {
+        return localPortChecker.isPortAvailable(port);
+    }
+}

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/IncrementingFreePortFinder.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/IncrementingFreePortFinder.java
@@ -1,0 +1,76 @@
+package org.kiwiproject.dropwizard.util.startup;
+
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
+import static org.kiwiproject.base.KiwiStrings.f;
+
+import org.kiwiproject.dropwizard.util.exception.NoAvailablePortException;
+import org.kiwiproject.net.LocalPortChecker;
+
+import java.util.stream.IntStream;
+
+/**
+ * Finds application and admin ports in an {@link AllowablePortRange}
+ * by traversing through each port number sequentially.
+ */
+public class IncrementingFreePortFinder implements FreePortFinder {
+
+    private final LocalPortChecker localPortChecker;
+
+    /**
+     * Create a new instance.
+     */
+    public IncrementingFreePortFinder() {
+        this(new LocalPortChecker());
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param localPortChecker the port checker to use
+     */
+    public IncrementingFreePortFinder(LocalPortChecker localPortChecker) {
+        this.localPortChecker = requireNotNull(localPortChecker, "localPortChecker must not be null");
+    }
+
+    /**
+     * Find the first two open ports in the given port range, assigning them to
+     * the application and admin ports, respectively.
+     * <p>
+     * The ports may or may not be adjacent, and non-adjacent ports may have one
+     * or more ports between them. If two open ports are found, the admin port
+     * number will always be higher than the application port number.
+     * <p>
+     * This method only returns a {@link ServicePorts} instance when there two open
+     * ports in the range. Otherwise, it throws a {@link NoAvailablePortException}.
+     *
+     * @param portRange the allowable port range, or {@code null}
+     * @return a new {@link ServicePorts} instance
+     * @throws NoAvailablePortException if two open ports were not found in the allowable port range
+     */
+    @Override
+    public ServicePorts find(AllowablePortRange portRange) {
+        checkArgumentNotNull(portRange, "portRange must not be null");
+
+        var ports = IntStream.iterate(
+                        portRange.getMinPortNumber(),
+                        port -> isBelowMaxPort(portRange, port),
+                        port -> port + 1)
+                .filter(localPortChecker::isPortAvailable)
+                .limit(2)
+                .toArray();
+
+        if (ports.length == 2) {
+            return new ServicePorts(ports[0], ports[1]);
+        }
+
+        var message = f("Could not find two open ports between {} and {}",
+                portRange.getMinPortNumber(),
+                portRange.getMaxPortNumber());
+        throw new NoAvailablePortException(message);
+    }
+
+    private static boolean isBelowMaxPort(AllowablePortRange portRange, int port) {
+        return port < portRange.getMaxPortNumber();
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/util/startup/AdjacentFreePortFinderTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/startup/AdjacentFreePortFinderTest.java
@@ -1,0 +1,131 @@
+package org.kiwiproject.dropwizard.util.startup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.dropwizard.util.exception.NoAvailablePortException;
+import org.kiwiproject.net.LocalPortChecker;
+
+@DisplayName("AdjacentFreePortFinder")
+class AdjacentFreePortFinderTest {
+
+    @Test
+    void shouldRequireLocalPortChecker() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new AdjacentFreePortFinder(null))
+                .withMessage("localPortChecker must not be null");
+    }
+
+    @Test
+    void shouldCreateIncrementingFreePortFinder() {
+        var portFinder = new AdjacentFreePortFinder();
+        var minPortNumber = 32_768;
+        var maxPortNumber = 49_151;
+        var range = new AllowablePortRange(minPortNumber, maxPortNumber);
+
+        var servicePorts = portFinder.find(range);
+
+        assertAll(
+                () -> assertThat(servicePorts.applicationPort()).isBetween(minPortNumber, maxPortNumber),
+                () -> assertThat(servicePorts.adminPort()).isBetween(minPortNumber, maxPortNumber),
+                () -> assertThat(servicePorts.adminPort()).isEqualTo(servicePorts.applicationPort() + 1)
+        );
+    }
+
+    @Test
+    void shouldNotAllowNull_AllowablePortRange() {
+        var portFinder = new AdjacentFreePortFinder();
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> portFinder.find(null))
+                .withMessage("portRange must not be null");
+    }
+
+    @Test
+    void shouldFindNextAdjacentApplicationAndAdminPorts_WhenFirstTwoAreNotInUse() {
+        var checker = mock(LocalPortChecker.class);
+        var portFinder = new AdjacentFreePortFinder(checker);
+
+        when(checker.isPortAvailable(anyInt())).thenReturn(true);
+
+        var minPortNumber = 35_000;
+        var maxPortNumber = 36_000;
+
+        var servicePorts = portFinder.find(new AllowablePortRange(minPortNumber, maxPortNumber));
+
+        assertAll(
+                () -> assertThat(servicePorts.applicationPort()).isEqualTo(minPortNumber),
+                () -> assertThat(servicePorts.adminPort()).isEqualTo(minPortNumber + 1)
+        );
+
+        verify(checker).isPortAvailable(minPortNumber);
+        verify(checker).isPortAvailable(minPortNumber + 1);
+        verifyNoMoreInteractions(checker);
+    }
+
+    @Test
+    void shouldFindNextAdjacentApplicationAndAdminPorts_WhenSomeAreInUse() {
+        var checker = mock(LocalPortChecker.class);
+        var portFinder = new AdjacentFreePortFinder(checker);
+
+        when(checker.isPortAvailable(anyInt()))
+                .thenReturn(false)
+                .thenReturn(true)
+                .thenReturn(false)
+                .thenReturn(false)
+                .thenReturn(false)
+                .thenReturn(true)
+                .thenReturn(false)
+                .thenReturn(true)
+                .thenReturn(false)
+                .thenReturn(true)
+                .thenReturn(false)
+                .thenReturn(false)
+                .thenReturn(false)
+                .thenReturn(true)
+                .thenReturn(false)
+                .thenReturn(true)
+                .thenReturn(true);
+
+        var minPortNumber = 9_000;
+        var maxPortNumber = 9_050;
+
+        var servicePorts = portFinder.find(new AllowablePortRange(minPortNumber, maxPortNumber));
+
+        assertAll(
+                () -> assertThat(servicePorts.applicationPort()).isBetween(minPortNumber, maxPortNumber),
+                () -> assertThat(servicePorts.adminPort()).isBetween(minPortNumber, maxPortNumber),
+                () -> assertThat(servicePorts.adminPort()).isEqualTo(servicePorts.applicationPort() + 1)
+        );
+
+        verify(checker, times(17)).isPortAvailable(anyInt());
+    }
+
+    @Test
+    void shouldThrowNoAvailablePortException_WhenNoPortsCanBeFound() {
+        var checker = mock(LocalPortChecker.class);
+        var portFinder = new AdjacentFreePortFinder(checker);
+
+        when(checker.isPortAvailable(anyInt())).thenReturn(false);
+
+        var minPortNumber = 9_000;
+        var maxPortNumber = 9_025;
+        var portRange = new AllowablePortRange(minPortNumber, maxPortNumber);
+
+        assertThatExceptionOfType(NoAvailablePortException.class)
+                .isThrownBy(() -> portFinder.find(portRange))
+                .withMessage("Could not find two adjacent open ports between %d and %d",
+                        minPortNumber, maxPortNumber);
+
+        verify(checker, times(portRange.getNumPortsInRange() - 1)).isPortAvailable(anyInt());
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/util/startup/IncrementingFreePortFinderTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/startup/IncrementingFreePortFinderTest.java
@@ -1,0 +1,123 @@
+package org.kiwiproject.dropwizard.util.startup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.dropwizard.util.exception.NoAvailablePortException;
+import org.kiwiproject.net.LocalPortChecker;
+
+@DisplayName("IncrementingFreePortFinder")
+class IncrementingFreePortFinderTest {
+
+    @Test
+    void shouldRequireLocalPortChecker() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new IncrementingFreePortFinder(null))
+                .withMessage("localPortChecker must not be null");
+    }
+
+    @Test
+    void shouldCreateIncrementingFreePortFinder() {
+        var portFinder = new IncrementingFreePortFinder();
+        var minPortNumber = 32_768;
+        var maxPortNumber = 49_151;
+        var range = new AllowablePortRange(minPortNumber, maxPortNumber);
+
+        var servicePorts = portFinder.find(range);
+
+        assertAll(
+                () -> assertThat(servicePorts.applicationPort()).isBetween(minPortNumber, maxPortNumber),
+                () -> assertThat(servicePorts.adminPort()).isBetween(minPortNumber, maxPortNumber),
+                () -> assertThat(servicePorts.adminPort()).isGreaterThan(servicePorts.applicationPort())
+        );
+    }
+
+    @Test
+    void shouldNotAllowNull_AllowablePortRange() {
+        var portFinder = new IncrementingFreePortFinder();
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> portFinder.find(null))
+                .withMessage("portRange must not be null");
+    }
+
+    @Test
+    void shouldFindNextApplicationAndAdminPorts_WhenFirstTwoAreOpen() {
+        var checker = mock(LocalPortChecker.class);
+        var portFinder = new IncrementingFreePortFinder(checker);
+
+        when(checker.isPortAvailable(anyInt())).thenReturn(true);
+
+        var minPortNumber = 9_000;
+        var maxPortNumber = 9_050;
+
+        var servicePorts = portFinder.find(new AllowablePortRange(minPortNumber, maxPortNumber));
+
+        assertAll(
+                () -> assertThat(servicePorts.applicationPort()).isEqualTo(9_000),
+                () -> assertThat(servicePorts.adminPort()).isEqualTo(9_001)
+        );
+    }
+
+    @Test
+    void shouldFindNextApplicationAndAdminPorts_WhenSomeAreInUse() {
+        var checker = mock(LocalPortChecker.class);
+        var portFinder = new IncrementingFreePortFinder(checker);
+
+        when(checker.isPortAvailable(anyInt()))
+                .thenReturn(false)  // 9000
+                .thenReturn(false)  // 9001
+                .thenReturn(true)   // 9002
+                .thenReturn(false)  // 9003
+                .thenReturn(false)  // 9004
+                .thenReturn(true);  // 9005
+
+        var minPortNumber = 9_000;
+        var maxPortNumber = 9_050;
+
+        var servicePorts = portFinder.find(new AllowablePortRange(minPortNumber, maxPortNumber));
+
+        assertAll(
+                () -> assertThat(servicePorts.applicationPort()).isEqualTo(9_002),
+                () -> assertThat(servicePorts.adminPort()).isEqualTo(9_005)
+        );
+
+        verify(checker).isPortAvailable(9_000);
+        verify(checker).isPortAvailable(9_001);
+        verify(checker).isPortAvailable(9_002);
+        verify(checker).isPortAvailable(9_003);
+        verify(checker).isPortAvailable(9_004);
+        verify(checker).isPortAvailable(9_005);
+        verifyNoMoreInteractions(checker);
+    }
+
+    @Test
+    void shouldThrowNoAvailablePortException_WhenNoPortsCanBeFound() {
+        var checker = mock(LocalPortChecker.class);
+        var portFinder = new IncrementingFreePortFinder(checker);
+
+        when(checker.isPortAvailable(anyInt())).thenReturn(false);
+
+        var minPortNumber = 9_000;
+        var maxPortNumber = 9_030;
+        var portRange = new AllowablePortRange(minPortNumber, maxPortNumber);
+
+        assertThatExceptionOfType(NoAvailablePortException.class)
+                .isThrownBy(() -> portFinder.find(portRange))
+                .withMessage("Could not find two open ports between %d and %d",
+                        minPortNumber, maxPortNumber);
+
+        var expectedNumberOfInvocations = maxPortNumber - minPortNumber;
+        verify(checker, times(expectedNumberOfInvocations)).isPortAvailable(anyInt());
+        verifyNoMoreInteractions(checker);
+    }
+}


### PR DESCRIPTION
* Add IncrementingFreePortFinder, which finds the first two open ports within the allowable port range whether adjacent or not. The admin port will always be higher than the application port.
* Add AdjacentFreePortFinder, which finds the first two open and adjacent ports within the allowable port range. The admin port will always be one higher than the application port.

Closes #538
Closes #539