### PR TITLE
Add additional logging in startup lock code

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/bundle/StartupLockBundle.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/bundle/StartupLockBundle.java
@@ -66,6 +66,8 @@ public abstract class StartupLockBundle<C extends Configuration>
                 startupLockConfig.getCuratorConfig(),
                 environment);
 
+        LOG.debug("For lock {}, state is {} ({})", lockPath, lockInfo.getLockState(), lockInfo.getInfoMessage());
+
         LOG.trace("Add fallback startup listener");
         startupLocker.addFallbackJettyStartupLifeCycleListener(lockInfo, environment);
 

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/StartupLocker.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/StartupLocker.java
@@ -100,6 +100,8 @@ public class StartupLocker {
             }
         }
 
+        LOG.info("Lock was not attempted because no ZooKeeper servers were available for connect string: {}",
+                curatorConfig.getZkConnectString());
         return StartupLockInfo.builder()
                 .lockState(StartupLockInfo.LockState.NOT_ATTEMPTED)
                 .infoMessage(format("No ZooKeepers are available from connect string [{}]", curatorConfig.getZkConnectString()))


### PR DESCRIPTION
* Add DEBUG logging in StartupLockBundle that contains the lock path, state of the LockInfo, and message from LockInfo.
* Add INFO level logging in StartupLocker explaining when a lock was not attempted b/c no Zookeeper servers were available.