### PR TITLE
Replace Checker annotations with JSpecify; remove redundant warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.kiwiproject</groupId>
             <artifactId>dropwizard-curator</artifactId>
         </dependency>

--- a/src/main/java/org/kiwiproject/dropwizard/util/bundle/DynamicPortsConfiguration.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/bundle/DynamicPortsConfiguration.java
@@ -10,7 +10,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Positive;
 import lombok.Builder;
 import lombok.Data;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.kiwiproject.config.TlsContextConfiguration;
 import org.kiwiproject.dropwizard.util.startup.FreePortFinder;
 import org.kiwiproject.dropwizard.util.startup.RandomFreePortFinder;

--- a/src/main/java/org/kiwiproject/dropwizard/util/bundle/StartupLockConfiguration.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/bundle/StartupLockConfiguration.java
@@ -62,7 +62,6 @@ public class StartupLockConfiguration {
      * <p>
      * The default value is {@link #DEFAULT_ZK_STARTUP_LOCK_TIMEOUT}.
      */
-    @SuppressWarnings("DefaultAnnotationParam")
     @NotNull
     @MinDuration(value = 1, unit = TimeUnit.SECONDS)
     private Duration zkStartupLockTimeout;

--- a/src/main/java/org/kiwiproject/dropwizard/util/job/JobExceptionInfo.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/job/JobExceptionInfo.java
@@ -4,7 +4,7 @@ import static java.util.Objects.nonNull;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.kiwiproject.base.KiwiThrowables;
 
 /**

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/PortAssigner.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/PortAssigner.java
@@ -14,7 +14,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.kiwiproject.config.TlsContextConfiguration;
 import org.kiwiproject.dropwizard.util.server.DropwizardConnectors;
 import org.kiwiproject.registry.model.Port;

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/RandomFreePortFinder.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/RandomFreePortFinder.java
@@ -6,7 +6,7 @@ import static org.kiwiproject.base.KiwiStrings.format;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.extern.slf4j.Slf4j;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.kiwiproject.dropwizard.util.exception.NoAvailablePortException;
 import org.kiwiproject.net.LocalPortChecker;
 

--- a/src/test/java/org/kiwiproject/dropwizard/util/config/JobScheduleTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/config/JobScheduleTest.java
@@ -9,7 +9,7 @@ import static org.kiwiproject.test.constants.KiwiTestConstants.JSON_HELPER;
 import io.dropwizard.util.Duration;
 import lombok.Getter;
 import lombok.Setter;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
* Replace Checker Nullable with JSpecify
* Remove redundant warning suppression in StartupLockConfiguration