### PR TITLE
Provide accessors that return values (not AtomicXxx) in MonitoredJob

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>dropwizard-service-utilities</artifactId>
-    <version>4.0.5-SNAPSHOT</version>
+    <version>4.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/MonitoredJobHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/MonitoredJobHealthCheck.java
@@ -123,16 +123,16 @@ public class MonitoredJobHealthCheck extends HealthCheck {
     @Override
     protected Result check() {
         try {
-            var lastRun = job.getLastSuccess().get();
+            var lastRun = job.lastSuccessMillis();
             if (!job.isActive()) {
                 return buildHealthyResult(f("Job is inactive. (last run: {})", instantToStringOrNever(lastRun)));
             }
 
             var now = kiwiEnvironment.currentTimeMillis();
-            var lastFailure = job.getLastFailure().get();
+            var lastFailure = job.lastFailureMillis();
             if ((now - lastFailure) < errorWarningMilliseconds) {
                 return buildUnhealthyResult(f("An error has occurred at: {}, which is within the threshold of: {}",
-                        instantToStringOrNever(job.getLastFailure().get()), errorWarningDurationString));
+                        instantToStringOrNever(lastFailure), errorWarningDurationString));
             }
 
             if ((now - getTimeOrServerStart(lastRun)) > warningThreshold) {
@@ -163,11 +163,11 @@ public class MonitoredJobHealthCheck extends HealthCheck {
         return resultBuilder
                 .withMessage(message)
                 .withDetail("jobName", job.getName())
-                .withDetail("totalErrors", job.getFailureCount())
-                .withDetail("lastFailure", job.getLastFailure())
-                .withDetail("lastJobExceptionInfo", job.getLastJobExceptionInfo())
-                .withDetail("lastSuccess", job.getLastSuccess())
-                .withDetail("lastExecutionTimeMs", job.getLastExecutionTime())
+                .withDetail("totalErrors", job.failureCount())
+                .withDetail("lastFailure", job.lastFailureMillis())
+                .withDetail("lastJobExceptionInfo", job.lastJobExceptionInfo())
+                .withDetail("lastSuccess", job.lastSuccessMillis())
+                .withDetail("lastExecutionTimeMs", job.lastExecutionTimeMillis())
                 .withDetail("expectedFrequencyMs", expectedFrequency)
                 .withDetail("warningThresholdMs", getWarningThreshold())
                 .withDetail("errorWarningDurationMs", errorWarningMilliseconds);

--- a/src/main/java/org/kiwiproject/dropwizard/util/job/MonitoredJob.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/job/MonitoredJob.java
@@ -12,8 +12,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
 import org.kiwiproject.base.CatchingRunnable;
 import org.kiwiproject.base.DefaultEnvironment;
+import org.kiwiproject.base.KiwiDeprecated;
 import org.kiwiproject.base.KiwiEnvironment;
 import org.kiwiproject.base.KiwiThrowables;
 
@@ -85,37 +87,58 @@ public class MonitoredJob implements CatchingRunnable {
 
     private final Duration timeout;
 
+    /**
+     * The name of this job.
+     */
     @Getter
     private final String name;
 
+    /**
+     * The decision function this job will use to determine whether to execute.
+     */
     @Getter(AccessLevel.PACKAGE)
     private final Predicate<MonitoredJob> decisionFunction;
 
+    /**
+     * The {@link KiwiEnvironment} to use.
+     */
     @Getter(AccessLevel.PACKAGE)
     private final KiwiEnvironment environment;
 
     /**
-     * Millis since epoch when job was last successful. Will be zero if job has never run or never succeeded.
+     * Millis since the epoch when the job was last successful. Will be zero if the job has never run or never succeeded.
      */
-    @Getter
+    @Getter(onMethod_ = {
+            @Deprecated(since = "4.1.0", forRemoval = true),
+            @KiwiDeprecated(replacedBy = "#lastSuccessMillis()", removeAt = "5.0.0")
+    })
     private final AtomicLong lastSuccess = new AtomicLong();
 
     /**
-     * Millis since epoch when job last failed. Will be zero if job has never run or never failed.
+     * Millis since the epoch when the job last failed. Will be zero if the job has never run or never failed.
      */
-    @Getter
+    @Getter(onMethod_ = {
+            @Deprecated(since = "4.1.0", forRemoval = true),
+            @KiwiDeprecated(replacedBy = "#lastFailureMillis()", removeAt = "5.0.0")
+    })
     private final AtomicLong lastFailure = new AtomicLong();
 
     /**
-     * Number of times job has failed. Will be zero if job has never run or never failed.
+     * Number of times the job has failed. Will be zero if the job has never run or never failed.
      */
-    @Getter
+    @Getter(onMethod_ = {
+            @Deprecated(since = "4.1.0", forRemoval = true),
+            @KiwiDeprecated(replacedBy = "#failureCount()", removeAt = "5.0.0")
+    })
     private final AtomicLong failureCount = new AtomicLong();
 
     /**
-     * Millis since epoch when job was last executed. Will be zero if job has never run.
+     * Millis since the epoch when the job was last executed. Will be zero if the job has never run.
      */
-    @Getter
+    @Getter(onMethod_ = {
+            @Deprecated(since = "4.1.0", forRemoval = true),
+            @KiwiDeprecated(replacedBy = "#lastExecutionTimeMillis()", removeAt = "5.0.0")
+    })
     private final AtomicLong lastExecutionTime = new AtomicLong();
 
     /**
@@ -123,7 +146,10 @@ public class MonitoredJob implements CatchingRunnable {
      * instance containing information about it. It intentionally does not store the actual
      * Exception instance.
      */
-    @Getter
+    @Getter(onMethod_ = {
+            @Deprecated(since = "4.1.0", forRemoval = true),
+            @KiwiDeprecated(replacedBy = "#lastJobExceptionInfo()", removeAt = "5.0.0")
+    })
     private final AtomicReference<JobExceptionInfo> lastJobExceptionInfo = new AtomicReference<>();
 
     @Builder
@@ -166,7 +192,7 @@ public class MonitoredJob implements CatchingRunnable {
     /**
      * Checks if the job should be active and execute by delegating to the decision function.
      * <p>
-     * This is useful if the same job runs in separate JVMs but only a single one of the jobs should run at a time.
+     * This is useful if the same job runs in separate JVMs, but only a single one of the jobs should run at a time.
      * For example, suppose there are multiple instances of a service that has a data cleanup job that runs
      * occasionally, but you only want one of the active instances to actually run the cleanup job. In this
      * situation, you could provide a decision function that uses a
@@ -212,5 +238,53 @@ public class MonitoredJob implements CatchingRunnable {
                             " Look for the exception and stack trace (probably above this message) logged by CatchingRunnable#runSafely.",
                     exceptionType, name, KiwiThrowables.typeOfNullable(rootCause).orElse(null));
         }
+    }
+
+    /**
+     * Millis since the epoch when the job was last successful. Will be zero if the job has never run or never succeeded.
+     *
+     * @return millis since the epoch when the job was last successful, or zero
+     */
+    public long lastSuccessMillis() {
+        return lastSuccess.get();
+    }
+
+    /**
+     * Millis since the epoch when the job last failed. Will be zero if the job has never run or never failed.
+     *
+     * @return millis since the epoch when the job last failed, or zero
+     */
+    public long lastFailureMillis() {
+        return lastFailure.get();
+    }
+
+    /**
+     * Number of times the job has failed. Will be zero if the job has never run or never failed.
+     *
+     * @return number of times the job has failed, or zero
+     */
+    public long failureCount() {
+        return failureCount.get();
+    }
+
+    /**
+     * Millis since the epoch when the job was last executed. Will be zero if the job has never run.
+     *
+     * @return millis since the epoch when the job was last executed, or zero
+     */
+    public long lastExecutionTimeMillis() {
+        return lastExecutionTime.get();
+    }
+
+    /**
+     * If the last job failure contained an exception, this will return a {@link JobExceptionInfo}
+     * instance containing information about it. It intentionally does not store the actual
+     * Exception instance. Otherwise, it returns {@code null}.
+     *
+     * @return the last exception if the job failed and contained an exception, or {@code null}
+     */
+    @Nullable
+    public JobExceptionInfo lastJobExceptionInfo() {
+        return lastJobExceptionInfo.get();
     }
 }

--- a/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobTest.java
@@ -61,6 +61,7 @@ class MonitoredJobTest {
     @Nested
     class Run {
 
+        @SuppressWarnings("removal")
         @Test
         void shouldRunSyncWithoutErrorWhenActive() {
             var environment = mock(KiwiEnvironment.class);
@@ -82,13 +83,19 @@ class MonitoredJobTest {
             assertAll(
                     () -> assertThat(taskRunCount.get()).isOne(),
                     () -> assertThat(job.getLastExecutionTime().get()).isOne(),
+                    () -> assertThat(job.lastExecutionTimeMillis()).isOne(),
                     () -> assertThat(job.getLastSuccess().get()).isEqualTo(mockedTime + 2),
+                    () -> assertThat(job.lastSuccessMillis()).isEqualTo(mockedTime + 2),
                     () -> assertThat(job.getLastFailure().get()).isZero(),
+                    () -> assertThat(job.lastFailureMillis()).isZero(),
                     () -> assertThat(job.getFailureCount().get()).isZero(),
-                    () -> assertThat(job.getLastJobExceptionInfo()).hasValue(null)
+                    () -> assertThat(job.failureCount()).isZero(),
+                    () -> assertThat(job.getLastJobExceptionInfo()).hasValue(null),
+                    () -> assertThat(job.lastJobExceptionInfo()).isNull()
             );
         }
 
+        @SuppressWarnings("removal")
         @Test
         void shouldRunAsyncWithoutErrorWhenActiveAndTimeoutIsSet() {
             var environment = mock(KiwiEnvironment.class);
@@ -112,13 +119,19 @@ class MonitoredJobTest {
             assertAll(
                     () -> assertThat(taskRunCount.get()).isOne(),
                     () -> assertThat(job.getLastExecutionTime().get()).isOne(),
+                    () -> assertThat(job.lastExecutionTimeMillis()).isOne(),
                     () -> assertThat(job.getLastSuccess().get()).isEqualTo(mockedTime + 2),
+                    () -> assertThat(job.lastSuccessMillis()).isEqualTo(mockedTime + 2),
                     () -> assertThat(job.getLastFailure().get()).isZero(),
+                    () -> assertThat(job.lastFailureMillis()).isZero(),
                     () -> assertThat(job.getFailureCount().get()).isZero(),
-                    () -> assertThat(job.getLastJobExceptionInfo()).hasValue(null)
+                    () -> assertThat(job.failureCount()).isZero(),
+                    () -> assertThat(job.getLastJobExceptionInfo()).hasValue(null),
+                    () -> assertThat(job.lastJobExceptionInfo()).isNull()
             );
         }
 
+        @SuppressWarnings("removal")
         @Test
         void shouldSkipExecutionWhenDecisionFunctionReturnsFalse() {
             var environment = mock(KiwiEnvironment.class);
@@ -139,13 +152,19 @@ class MonitoredJobTest {
             assertAll(
                     () -> assertThat(taskRunCount.get()).isZero(),
                     () -> assertThat(job.getLastExecutionTime().get()).isZero(),
+                    () -> assertThat(job.lastExecutionTimeMillis()).isZero(),
                     () -> assertThat(job.getLastSuccess().get()).isEqualTo(mockedTime),
+                    () -> assertThat(job.lastSuccessMillis()).isEqualTo(mockedTime),
                     () -> assertThat(job.getLastFailure().get()).isZero(),
+                    () -> assertThat(job.lastFailureMillis()).isZero(),
                     () -> assertThat(job.getFailureCount().get()).isZero(),
-                    () -> assertThat(job.getLastJobExceptionInfo()).hasValue(null)
+                    () -> assertThat(job.failureCount()).isZero(),
+                    () -> assertThat(job.getLastJobExceptionInfo()).hasValue(null),
+                    () -> assertThat(job.lastJobExceptionInfo()).isNull()
             );
         }
 
+        @SuppressWarnings("removal")
         @Test
         void shouldTrackErrorWhenTaskFails() {
             var environment = mock(KiwiEnvironment.class);
@@ -164,13 +183,19 @@ class MonitoredJobTest {
 
             assertAll(
                     () -> assertThat(job.getLastExecutionTime().get()).isZero(),
+                    () -> assertThat(job.lastExecutionTimeMillis()).isZero(),
                     () -> assertThat(job.getLastSuccess().get()).isZero(),
+                    () -> assertThat(job.lastSuccessMillis()).isZero(),
                     () -> assertThat(job.getLastFailure().get()).isEqualTo(mockedTime + 1),
+                    () -> assertThat(job.lastFailureMillis()).isEqualTo(mockedTime + 1),
                     () -> assertThat(job.getFailureCount().get()).isOne(),
-                    () -> assertThat(job.getLastJobExceptionInfo()).hasValue(JobExceptionInfo.from(newSampleException()))
+                    () -> assertThat(job.failureCount()).isOne(),
+                    () -> assertThat(job.getLastJobExceptionInfo()).hasValue(JobExceptionInfo.from(newSampleException())),
+                    () -> assertThat(job.lastJobExceptionInfo()).isEqualTo(JobExceptionInfo.from(newSampleException()))
             );
         }
 
+        @SuppressWarnings("removal")
         @Test
         void shouldHandleErrorWhenTaskFailsAndHandlerSet() {
             var environment = mock(KiwiEnvironment.class);
@@ -198,11 +223,16 @@ class MonitoredJobTest {
 
             assertAll(
                     () -> assertThat(job.getLastExecutionTime().get()).isZero(),
+                    () -> assertThat(job.lastExecutionTimeMillis()).isZero(),
                     () -> assertThat(job.getLastSuccess().get()).isZero(),
+                    () -> assertThat(job.lastSuccessMillis()).isZero(),
                     () -> assertThat(job.getLastFailure().get()).isEqualTo(mockedTime + 1),
+                    () -> assertThat(job.lastFailureMillis()).isEqualTo(mockedTime + 1),
                     () -> assertThat(job.getFailureCount().get()).isOne(),
+                    () -> assertThat(job.failureCount()).isOne(),
                     () -> assertThat(taskHandledCount.get()).isOne(),
-                    () -> assertThat(job.getLastJobExceptionInfo()).hasValue(JobExceptionInfo.from(newSampleException()))
+                    () -> assertThat(job.getLastJobExceptionInfo()).hasValue(JobExceptionInfo.from(newSampleException())),
+                    () -> assertThat(job.lastJobExceptionInfo()).isEqualTo(JobExceptionInfo.from(newSampleException()))
             );
         }
 

--- a/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobsTest.java
@@ -250,7 +250,7 @@ class MonitoredJobsTest {
 
             private boolean executedMoreThanFiveMinutesAgo(MonitoredJob job) {
                 var now = System.currentTimeMillis();
-                var lastExecuted = job.getLastExecutionTime().get();
+                var lastExecuted = job.lastExecutionTimeMillis();
                 var millisSinceLastExecuted = now - lastExecuted;
                 return millisSinceLastExecuted > TimeUnit.MINUTES.toMillis(5);
             }
@@ -275,9 +275,9 @@ class MonitoredJobsTest {
 
                     await().atMost(Durations.TWO_SECONDS).until(() -> count.get() >= 1);
 
-                    assertThat(job.getLastSuccess()).hasValueGreaterThan(Instant.now().minusSeconds(2).toEpochMilli());
-                    assertThat(job.getLastFailure()).hasValue(0);
-                    assertThat(job.getFailureCount()).hasValue(0);
+                    assertThat(job.lastSuccessMillis()).isGreaterThan(Instant.now().minusSeconds(2).toEpochMilli());
+                    assertThat(job.lastFailureMillis()).isZero();
+                    assertThat(job.failureCount()).isZero();
 
                     assertHealthCheckWasRegistered(job);
                 });


### PR DESCRIPTION
* Add record-style accessors to MonitoredJob to return the values for last success, failure, execution, etc. instead of references to AtomicLong and AtomicReference.
* Deprecate the accessors in MonitoredJob that return (mutable) references to AtomicLong and AtomicReference.
* Update MonitoredJobHealthCheck to use the new accessors.
* Modify tests (other than MonitoredJobTest) to use the new accessors.
* Update MonitoredJobTest to test the new accessors in addition to the original ones, and suppress the warnings about deprecation and removal since they still need to be tested while they exist.

Closes #584
Closes #587