### PR TITLE
Add accessors to MonitoredJob returning java.time objects

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/job/MonitoredJob.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/job/MonitoredJob.java
@@ -20,6 +20,7 @@ import org.kiwiproject.base.KiwiEnvironment;
 import org.kiwiproject.base.KiwiThrowables;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -133,7 +134,8 @@ public class MonitoredJob implements CatchingRunnable {
     private final AtomicLong failureCount = new AtomicLong();
 
     /**
-     * Millis since the epoch when the job was last executed. Will be zero if the job has never run.
+     * The duration in milliseconds of the job's last <em>successful</em> execution.
+     * Will be zero if the job has never run or never succeeded.
      */
     @Getter(onMethod_ = {
             @Deprecated(since = "4.1.0", forRemoval = true),
@@ -250,12 +252,32 @@ public class MonitoredJob implements CatchingRunnable {
     }
 
     /**
+     * Returns the instant when the job was last successful. Will be the epoch (1970-01-01T00:00:00Z)
+     * if the job has never run or never succeeded.
+     *
+     * @return instant when the job was last successful, or the epoch
+     */
+    public Instant lastSuccess() {
+        return Instant.ofEpochMilli(lastSuccessMillis());
+    }
+
+    /**
      * Millis since the epoch when the job last failed. Will be zero if the job has never run or never failed.
      *
      * @return millis since the epoch when the job last failed, or zero
      */
     public long lastFailureMillis() {
         return lastFailure.get();
+    }
+
+    /**
+     * Returns the instant when the job last failed. Will be the epoch (1970-01-01T00:00:00Z)
+     * if the job has never run or never failed.
+     *
+     * @return instant when the job last failed, or the epoch
+     */
+    public Instant lastFailure() {
+        return Instant.ofEpochMilli(lastFailureMillis());
     }
 
     /**
@@ -268,12 +290,23 @@ public class MonitoredJob implements CatchingRunnable {
     }
 
     /**
-     * Millis since the epoch when the job was last executed. Will be zero if the job has never run.
+     * The duration in milliseconds of the job's last <em>successful</em> execution.
+     * Will be zero if the job has never run or never succeeded.
      *
-     * @return millis since the epoch when the job was last executed, or zero
+     * @return duration of the job's last successful execution in milliseconds, or zero
      */
     public long lastExecutionTimeMillis() {
         return lastExecutionTime.get();
+    }
+
+    /**
+     * The duration of the job's last <em>successful</em> execution.
+     * Will be the zero if the job has never run or never succeeded.
+     *
+     * @return duration of the job's last successful execution, or zero
+     */
+    public Duration lastExecutionTime() {
+        return Duration.ofMillis(lastExecutionTimeMillis());
     }
 
     /**

--- a/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobTest.java
@@ -17,6 +17,7 @@ import org.kiwiproject.test.junit.jupiter.ClearBoxTest;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -84,10 +85,13 @@ class MonitoredJobTest {
                     () -> assertThat(taskRunCount.get()).isOne(),
                     () -> assertThat(job.getLastExecutionTime().get()).isOne(),
                     () -> assertThat(job.lastExecutionTimeMillis()).isOne(),
+                    () -> assertThat(job.lastExecutionTime()).isEqualTo(Duration.ofMillis(1)),
                     () -> assertThat(job.getLastSuccess().get()).isEqualTo(mockedTime + 2),
                     () -> assertThat(job.lastSuccessMillis()).isEqualTo(mockedTime + 2),
+                    () -> assertThat(job.lastSuccess()).isEqualTo(Instant.ofEpochMilli(mockedTime + 2)),
                     () -> assertThat(job.getLastFailure().get()).isZero(),
                     () -> assertThat(job.lastFailureMillis()).isZero(),
+                    () -> assertThat(job.lastFailure()).isEqualTo(Instant.EPOCH),
                     () -> assertThat(job.getFailureCount().get()).isZero(),
                     () -> assertThat(job.failureCount()).isZero(),
                     () -> assertThat(job.getLastJobExceptionInfo()).hasValue(null),
@@ -120,10 +124,13 @@ class MonitoredJobTest {
                     () -> assertThat(taskRunCount.get()).isOne(),
                     () -> assertThat(job.getLastExecutionTime().get()).isOne(),
                     () -> assertThat(job.lastExecutionTimeMillis()).isOne(),
+                    () -> assertThat(job.lastExecutionTime()).isEqualTo(Duration.ofMillis(1)),
                     () -> assertThat(job.getLastSuccess().get()).isEqualTo(mockedTime + 2),
                     () -> assertThat(job.lastSuccessMillis()).isEqualTo(mockedTime + 2),
+                    () -> assertThat(job.lastSuccess()).isEqualTo(Instant.ofEpochMilli(mockedTime + 2)),
                     () -> assertThat(job.getLastFailure().get()).isZero(),
                     () -> assertThat(job.lastFailureMillis()).isZero(),
+                    () -> assertThat(job.lastFailure()).isEqualTo(Instant.EPOCH),
                     () -> assertThat(job.getFailureCount().get()).isZero(),
                     () -> assertThat(job.failureCount()).isZero(),
                     () -> assertThat(job.getLastJobExceptionInfo()).hasValue(null),
@@ -153,10 +160,13 @@ class MonitoredJobTest {
                     () -> assertThat(taskRunCount.get()).isZero(),
                     () -> assertThat(job.getLastExecutionTime().get()).isZero(),
                     () -> assertThat(job.lastExecutionTimeMillis()).isZero(),
+                    () -> assertThat(job.lastExecutionTime()).isEqualTo(Duration.ZERO),
                     () -> assertThat(job.getLastSuccess().get()).isEqualTo(mockedTime),
                     () -> assertThat(job.lastSuccessMillis()).isEqualTo(mockedTime),
+                    () -> assertThat(job.lastSuccess()).isEqualTo(Instant.ofEpochMilli(mockedTime)),
                     () -> assertThat(job.getLastFailure().get()).isZero(),
                     () -> assertThat(job.lastFailureMillis()).isZero(),
+                    () -> assertThat(job.lastFailure()).isEqualTo(Instant.EPOCH),
                     () -> assertThat(job.getFailureCount().get()).isZero(),
                     () -> assertThat(job.failureCount()).isZero(),
                     () -> assertThat(job.getLastJobExceptionInfo()).hasValue(null),
@@ -184,10 +194,13 @@ class MonitoredJobTest {
             assertAll(
                     () -> assertThat(job.getLastExecutionTime().get()).isZero(),
                     () -> assertThat(job.lastExecutionTimeMillis()).isZero(),
+                    () -> assertThat(job.lastExecutionTime()).isEqualTo(Duration.ZERO),
                     () -> assertThat(job.getLastSuccess().get()).isZero(),
                     () -> assertThat(job.lastSuccessMillis()).isZero(),
+                    () -> assertThat(job.lastSuccess()).isEqualTo(Instant.EPOCH),
                     () -> assertThat(job.getLastFailure().get()).isEqualTo(mockedTime + 1),
                     () -> assertThat(job.lastFailureMillis()).isEqualTo(mockedTime + 1),
+                    () -> assertThat(job.lastFailure()).isEqualTo(Instant.ofEpochMilli(mockedTime + 1)),
                     () -> assertThat(job.getFailureCount().get()).isOne(),
                     () -> assertThat(job.failureCount()).isOne(),
                     () -> assertThat(job.getLastJobExceptionInfo()).hasValue(JobExceptionInfo.from(newSampleException())),
@@ -224,10 +237,13 @@ class MonitoredJobTest {
             assertAll(
                     () -> assertThat(job.getLastExecutionTime().get()).isZero(),
                     () -> assertThat(job.lastExecutionTimeMillis()).isZero(),
+                    () -> assertThat(job.lastExecutionTime()).isEqualTo(Duration.ZERO),
                     () -> assertThat(job.getLastSuccess().get()).isZero(),
                     () -> assertThat(job.lastSuccessMillis()).isZero(),
+                    () -> assertThat(job.lastSuccess()).isEqualTo(Instant.EPOCH),
                     () -> assertThat(job.getLastFailure().get()).isEqualTo(mockedTime + 1),
                     () -> assertThat(job.lastFailureMillis()).isEqualTo(mockedTime + 1),
+                    () -> assertThat(job.lastFailure()).isEqualTo(Instant.ofEpochMilli(mockedTime + 1)),
                     () -> assertThat(job.getFailureCount().get()).isOne(),
                     () -> assertThat(job.failureCount()).isOne(),
                     () -> assertThat(taskHandledCount.get()).isOne(),


### PR DESCRIPTION
* Introduce new accessors that return Instant: lastSuccess, lastFailure
* Add a new accessor that returns Duration: lastExecutionTime
* Fix the Javadocs for lastExecutionTime that have been wrong for many years. It is the duration of the last successful execution, not the time since the epoch.

Closes #589
Closes #590