### PR TITLE
Code cleanup: renaming fields and vars in MonitoredJobHealthCheck

### DIFF
--- a/src/test/java/org/kiwiproject/dropwizard/util/health/MonitoredJobHealthCheckTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/health/MonitoredJobHealthCheckTest.java
@@ -62,7 +62,7 @@ class MonitoredJobHealthCheckTest {
             assertThat(healthCheck.getErrorWarningDuration()).isEqualTo(MonitoredJobHealthCheck.DEFAULT_WARNING_DURATION);
             assertThat(healthCheck.getThresholdFactor()).isEqualTo(MonitoredJobHealthCheck.DEFAULT_THRESHOLD_FACTOR);
             assertThat(healthCheck.getKiwiEnvironment()).isNotNull();
-            assertThat(healthCheck.getLowerTimeBound()).isPositive();
+            assertThat(healthCheck.getLowerTimeBoundTimestampMillis()).isPositive();
         }
     }
 


### PR DESCRIPTION
* Rename private fields and local vars in MonitoredJobHealthCheck to be more consistent in terms of what is a timestamp, what is a duration, what the unit is, etc. It's not perfect, but it's better.
* Change calculateWarningThreshold to a static method and add arguments for clarity.
* Rename several method parameters for clarity.