### PR TITLE
Make MonitoredJobHealthCheck details consistent and human-readable

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/health/MonitoredJobHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/MonitoredJobHealthCheck.java
@@ -166,13 +166,19 @@ public class MonitoredJobHealthCheck extends HealthCheck {
                 .withMessage(message)
                 .withDetail("jobName", job.getName())
                 .withDetail("totalErrors", job.failureCount())
-                .withDetail("lastFailure", job.lastFailureMillis())
+                .withDetail("lastFailureTimestamp", job.lastFailureMillis())
+                .withDetail("lastFailureTime", instantToStringOrNever(job.lastFailureMillis()))
                 .withDetail("lastJobExceptionInfo", job.lastJobExceptionInfo())
-                .withDetail("lastSuccess", job.lastSuccessMillis())
-                .withDetail("lastExecutionTimeMs", job.lastExecutionTimeMillis())
-                .withDetail("expectedFrequencyMs", expectedFrequencyMilliseconds)
-                .withDetail("warningThresholdMs", warningThresholdDurationMilliseconds)
-                .withDetail("errorWarningDurationMs", errorWarningDurationMilliseconds);
+                .withDetail("lastSuccessTimestamp", job.lastSuccessMillis())
+                .withDetail("lastSuccessTime", instantToStringOrNever(job.lastSuccessMillis()))
+                .withDetail("lastSuccessfulExecutionDurationMs", job.lastExecutionTimeMillis())
+                .withDetail("lastSuccessfulExecutionDuration", formatMillisecondDurationWords(job.lastExecutionTimeMillis()))
+                .withDetail("expectedJobFrequencyMs", expectedFrequencyMilliseconds)
+                .withDetail("expectedJobFrequency", formatMillisecondDurationWords(expectedFrequencyMilliseconds))
+                .withDetail("warningThresholdDurationMs", warningThresholdDurationMilliseconds)
+                .withDetail("warningThresholdDuration", warningThresholdDurationString)
+                .withDetail("recentErrorWarningDurationMs", errorWarningDurationMilliseconds)
+                .withDetail("recentErrorWarningDuration", errorWarningDurationString);
     }
 
     private static void checkValidHealthArgumentCombination(boolean healthy, Exception error) {

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/MonitoredJobHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/MonitoredJobHealthCheck.java
@@ -162,17 +162,21 @@ public class MonitoredJobHealthCheck extends HealthCheck {
         var resultBuilder = isNull(error) ? newResultBuilder(healthy)
                 : newUnhealthyResultBuilder(error);
 
+        var lastFailureMillis = job.lastFailureMillis();
+        var lastSuccessMillis = job.lastSuccessMillis();
+        var lastExecutionTimeMillis = job.lastExecutionTimeMillis();
+
         return resultBuilder
                 .withMessage(message)
                 .withDetail("jobName", job.getName())
                 .withDetail("totalErrors", job.failureCount())
-                .withDetail("lastFailureTimestamp", job.lastFailureMillis())
-                .withDetail("lastFailureTime", instantToStringOrNever(job.lastFailureMillis()))
+                .withDetail("lastFailureTimestamp", lastFailureMillis)
+                .withDetail("lastFailureTime", instantToStringOrNever(lastFailureMillis))
                 .withDetail("lastJobExceptionInfo", job.lastJobExceptionInfo())
-                .withDetail("lastSuccessTimestamp", job.lastSuccessMillis())
-                .withDetail("lastSuccessTime", instantToStringOrNever(job.lastSuccessMillis()))
-                .withDetail("lastSuccessfulExecutionDurationMs", job.lastExecutionTimeMillis())
-                .withDetail("lastSuccessfulExecutionDuration", formatMillisecondDurationWords(job.lastExecutionTimeMillis()))
+                .withDetail("lastSuccessTimestamp", lastSuccessMillis)
+                .withDetail("lastSuccessTime", instantToStringOrNever(lastSuccessMillis))
+                .withDetail("lastSuccessfulExecutionDurationMs", lastExecutionTimeMillis)
+                .withDetail("lastSuccessfulExecutionDuration", formatMillisecondDurationWords(lastExecutionTimeMillis))
                 .withDetail("expectedJobFrequencyMs", expectedFrequencyMilliseconds)
                 .withDetail("expectedJobFrequency", formatMillisecondDurationWords(expectedFrequencyMilliseconds))
                 .withDetail("warningThresholdDurationMs", warningThresholdDurationMilliseconds)

--- a/src/test/java/org/kiwiproject/dropwizard/util/health/MonitoredJobHealthCheckTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/health/MonitoredJobHealthCheckTest.java
@@ -183,9 +183,21 @@ class MonitoredJobHealthCheckTest {
             assertThatHealthCheck(healthCheck)
                     .isHealthy()
                     .hasMessage(messageTemplate, args)
-                    .hasDetailsContainingKeys("jobName", "totalErrors", "lastFailure", "lastSuccess",
-                            "lastExecutionTimeMs", "expectedFrequencyMs", "errorWarningDurationMs")
-                    .hasDetail("warningThresholdMs", MonitoredJobHealthCheck.MINIMUM_WARNING_THRESHOLD.toMilliseconds());
+                    .hasDetailsContainingKeys("jobName",
+                            "totalErrors",
+                            "lastFailureTimestamp",
+                            "lastFailureTime",
+                            "lastSuccessTimestamp",
+                            "lastSuccessTime",
+                            "lastSuccessfulExecutionDurationMs",
+                            "lastSuccessfulExecutionDuration",
+                            "expectedJobFrequencyMs",
+                            "expectedJobFrequency",
+                            "recentErrorWarningDurationMs",
+                            "recentErrorWarningDuration"
+                    )
+                    .hasDetail("warningThresholdDurationMs", MonitoredJobHealthCheck.MINIMUM_WARNING_THRESHOLD.toMilliseconds())
+                    .hasDetail("warningThresholdDuration", formatDropwizardDurationWords(MonitoredJobHealthCheck.MINIMUM_WARNING_THRESHOLD));
         }
     }
 
@@ -292,13 +304,20 @@ class MonitoredJobHealthCheckTest {
                     .hasDetailsContainingKeys(
                             "jobName",
                             "totalErrors",
-                            "lastFailure",
+                            "lastFailureTimestamp",
+                            "lastFailureTime",
                             "lastJobExceptionInfo",
-                            "lastSuccess",
-                            "lastExecutionTimeMs",
-                            "expectedFrequencyMs",
-                            "errorWarningDurationMs")
-                    .hasDetail("warningThresholdMs", MonitoredJobHealthCheck.MINIMUM_WARNING_THRESHOLD.toMilliseconds());
+                            "lastSuccessTimestamp",
+                            "lastSuccessTime",
+                            "lastSuccessfulExecutionDurationMs",
+                            "lastSuccessfulExecutionDuration",
+                            "expectedJobFrequencyMs",
+                            "expectedJobFrequency",
+                            "recentErrorWarningDurationMs",
+                            "recentErrorWarningDuration"
+                    )
+                    .hasDetail("warningThresholdDurationMs", MonitoredJobHealthCheck.MINIMUM_WARNING_THRESHOLD.toMilliseconds())
+                    .hasDetail("warningThresholdDuration", formatDropwizardDurationWords(MonitoredJobHealthCheck.MINIMUM_WARNING_THRESHOLD));
         }
     }
 }


### PR DESCRIPTION
* Rename the lastFailure detail to lastFailureTimestamp.
* Rename the lastSuccess detail to lastSuccessTimestamp.
* Rename the lastExecutionTimeMs detail to lastSuccessfulExecutionDurationMs.
* Rename the expectedFrequencyMs detail to expectedJobFrequencyMs.
* Rename the errorWarningDurationMs detail to recentErrorWarningDurationMs.
* Rename the warningThresholdMs detail to warningThresholdDurationMs.
* Add lastFailureTime detail (human-readable of lastSuccessTimestamp).
* Add lastSuccessfulExecutionDuration detail (human-readable of lastSuccessfulExecutionDurationMs).
* Add expectedJobFrequency detail (human-readable of expectedJobFrequencyMs).
* Add warningThresholdDuration detail (human-readable of warningThresholdDurationMs).
* Add recentErrorWarningDuration detail (human-readable of recentErrorWarningDurationMs).

Closes #598 