### PR TITLE
Add the ability to get and clear registered job names to MonitoredJobs

### DIFF
--- a/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.common.util.concurrent.Runnables;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -49,7 +50,7 @@ class MonitoredJobTest {
         void shouldSetDefaults() {
             var job = MonitoredJob.builder()
                     .name("Name and Task Job")
-                    .task(() -> System.out.println("Hello"))
+                    .task(Runnables.doNothing())
                     .build();
 
             assertAll(

--- a/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobsTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.util.concurrent.Runnables;
 import io.dropwizard.core.setup.Environment;
 import io.dropwizard.lifecycle.setup.ScheduledExecutorServiceBuilder;
 import io.dropwizard.util.Duration;
@@ -77,7 +78,7 @@ class MonitoredJobsTest {
 
                 when(scheduledExecutorServiceBuilder.build()).thenReturn(mock(ScheduledExecutorService.class));
 
-                task = () -> System.out.println("hello");
+                task = Runnables.doNothing();
 
                 schedule = JobSchedule.builder()
                         .intervalDelay(Duration.minutes(5))
@@ -141,7 +142,7 @@ class MonitoredJobsTest {
             void whenIntervalDelayIsNotPositive(long intervalDelaySeconds) {
                 var jobName = "NotPositiveIntervalDelay";
 
-                var schedule = JobSchedule.ofIntervalDelay(Duration.seconds(intervalDelaySeconds));
+                schedule = JobSchedule.ofIntervalDelay(Duration.seconds(intervalDelaySeconds));
 
                 assertThatIllegalArgumentException()
                         .isThrownBy(() -> MonitoredJobs.registerJob(env, jobName,
@@ -216,7 +217,7 @@ class MonitoredJobsTest {
                         .intervalDelay(Duration.seconds(30))
                         .build();
 
-                task = () -> System.out.println("hello");
+                task = Runnables.doNothing();
                 executor = mock(ScheduledExecutorService.class);
 
                 var scheduledExecutorServiceBuilder = mock(ScheduledExecutorServiceBuilder.class);
@@ -359,7 +360,7 @@ class MonitoredJobsTest {
 
             when(scheduledExecutorServiceBuilder.build()).thenReturn(mock(ScheduledExecutorService.class));
 
-            task = () -> System.out.println("hello");
+            task = Runnables.doNothing();
 
             schedule = JobSchedule.builder()
                     .intervalDelay(Duration.minutes(5))

--- a/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/job/MonitoredJobsTest.java
@@ -1,5 +1,6 @@
 package org.kiwiproject.dropwizard.util.job;
 
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.awaitility.Awaitility.await;
@@ -13,13 +14,18 @@ import static org.mockito.Mockito.when;
 import io.dropwizard.core.setup.Environment;
 import io.dropwizard.lifecycle.setup.ScheduledExecutorServiceBuilder;
 import io.dropwizard.util.Duration;
+import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.awaitility.Durations;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.kiwiproject.base.KiwiEnvironment;
 import org.kiwiproject.dropwizard.util.concurrent.TestExecutors;
 import org.kiwiproject.dropwizard.util.config.JobSchedule;
@@ -27,11 +33,15 @@ import org.kiwiproject.dropwizard.util.health.MonitoredJobHealthCheck;
 import org.kiwiproject.test.dropwizard.mockito.DropwizardMockitoMocks;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 
+@Slf4j
 @DisplayName("MonitoredJobs")
 @ExtendWith(SoftAssertionsExtension.class)
 class MonitoredJobsTest {
@@ -39,9 +49,15 @@ class MonitoredJobsTest {
     private Environment env;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         env = DropwizardMockitoMocks.mockEnvironment();
     }
+
+    @AfterEach
+    void tearDown() {
+        MonitoredJobs.JOBS.clear();
+    }
+
 
     @Nested
     class RegisterJob {
@@ -94,6 +110,22 @@ class MonitoredJobsTest {
                         .withMessage("Job '%s' must specify a non-null initial delay", jobName);
             }
 
+            @ParameterizedTest
+            @ValueSource(ints = {-10, -5, -1})
+            void whenInitialDelayIsNegative(int initialDelaySeconds) {
+                var jobName = "NegativeInitialDelay";
+
+                schedule = JobSchedule.builder()
+                        .initialDelay(Duration.seconds(initialDelaySeconds))
+                        .intervalDelay(Duration.seconds(1))
+                        .build();
+
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> MonitoredJobs.registerJob(env, jobName,
+                                schedule, task))
+                        .withMessage("Job '%s' must specify a non-negative initial delay", jobName);
+            }
+
             @Test
             void whenIntervalDelayIsMissing() {
                 var jobName = "MissingIntervalDelay";
@@ -102,6 +134,19 @@ class MonitoredJobsTest {
                         .isThrownBy(() -> MonitoredJobs.registerJob(env, jobName,
                                 new JobSchedule(), task))
                         .withMessage("Job '%s' must specify a non-null interval delay", jobName);
+            }
+
+            @ParameterizedTest
+            @ValueSource(ints = {-5, -1, 0})
+            void whenIntervalDelayIsNotPositive(long intervalDelaySeconds) {
+                var jobName = "NotPositiveIntervalDelay";
+
+                var schedule = JobSchedule.ofIntervalDelay(Duration.seconds(intervalDelaySeconds));
+
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> MonitoredJobs.registerJob(env, jobName,
+                                schedule, task))
+                        .withMessage("Job '%s' must specify a positive interval delay", jobName);
             }
 
             @Nested
@@ -166,8 +211,6 @@ class MonitoredJobsTest {
 
             @BeforeEach
             void setUp() {
-                MonitoredJobs.JOBS.clear();
-
                 schedule = JobSchedule.builder()
                         .initialDelay(Duration.seconds(10))
                         .intervalDelay(Duration.seconds(30))
@@ -298,6 +341,79 @@ class MonitoredJobsTest {
                 verify(env.healthChecks())
                         .register(eq("Job: " + job.getName()), any(MonitoredJobHealthCheck.class));
             }
+        }
+    }
+
+    @Nested
+    class RegisteredJobNames {
+
+        private JobSchedule schedule;
+        private Runnable task;
+
+        @BeforeEach
+        void setUp() {
+            var scheduledExecutorServiceBuilder = mock(ScheduledExecutorServiceBuilder.class);
+
+            when(env.lifecycle().scheduledExecutorService(anyString(), eq(true)))
+                    .thenReturn(scheduledExecutorServiceBuilder);
+
+            when(scheduledExecutorServiceBuilder.build()).thenReturn(mock(ScheduledExecutorService.class));
+
+            task = () -> System.out.println("hello");
+
+            schedule = JobSchedule.builder()
+                    .intervalDelay(Duration.minutes(5))
+                    .build();
+        }
+
+        @RepeatedTest(5)
+        void shouldClearAndGetRegisteredJobNames() {
+            // Register a random number of jobs between 5 and 15 (exclusive).
+            // The jobs are registered in a random order.
+            var n = ThreadLocalRandom.current().nextInt(5, 15);
+            var jobNumbers = IntStream.rangeClosed(1, n).boxed().collect(toList());
+            Collections.shuffle(jobNumbers);
+            LOG.debug("{} jobNumbers: {}", jobNumbers.size(), jobNumbers);
+            jobNumbers.forEach(number ->
+                    MonitoredJobs.registerJob(env, "Job" + number, schedule, task));
+
+            var expectedJobNames = jobNumbers.stream()
+                    .map(num -> "Job" + num)
+                    .sorted()
+                    .toArray(String[]::new);
+
+            assertThat(MonitoredJobs.registeredJobNames())
+                    .describedAs("job names should be sorted")
+                    .containsExactly(expectedJobNames);
+
+            var previouslyRegisteredJobNames = MonitoredJobs.clearRegisteredJobNames();
+            assertThat(previouslyRegisteredJobNames)
+                    .describedAs("should see sorted job names")
+                    .containsExactly(expectedJobNames);
+
+            assertThat(MonitoredJobs.registeredJobNames())
+                    .describedAs("job names should be empty after clearing")
+                    .isEmpty();
+        }
+
+        @Test
+        void shouldReturnUnmodifiableSetOfJobNames() {
+            MonitoredJobs.registerJob(env, "Job-A", schedule, task);
+            MonitoredJobs.registerJob(env, "Job-B", schedule, task);
+            MonitoredJobs.registerJob(env, "Job-C", schedule, task);
+
+            var jobNames = MonitoredJobs.registeredJobNames();
+            assertThat(jobNames).isUnmodifiable();
+        }
+
+        @Test
+        void shouldReturnUnmodifiableSetOfJobNames_ForClear() {
+            MonitoredJobs.registerJob(env, "Job-A", schedule, task);
+            MonitoredJobs.registerJob(env, "Job-B", schedule, task);
+            MonitoredJobs.registerJob(env, "Job-C", schedule, task);
+
+            var clearedJobNames = MonitoredJobs.clearRegisteredJobNames();
+            assertThat(clearedJobNames).isUnmodifiable();
         }
     }
 }


### PR DESCRIPTION
* Add the registeredJobNames method to return a sorted, unmodifiable set containing the names of the registered jobs.
* Add the clearRegisteredJobNames method to clear out the previously registered job names
* Add more validation of the JobSchedule to ensure that the initial delay is non-negative and that the interval delay is positive.
* Update Javadocs of the registerJob methods to state that an IllegalArgumentException is thrown if a job has already been registered with the same name.
* Change the dummy tasks in MonitoredJobTest and MonitoredJobsTest
  to use Guava's Runnables.doNothing()

Closes #610
Closes #613