### PR TITLE
Add configurable timeout to MongoHealthCheck

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>dropwizard-service-utilities</artifactId>
-    <version>5.0.3-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/MongoHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/MongoHealthCheck.java
@@ -1,5 +1,6 @@
 package org.kiwiproject.dropwizard.util.health;
 
+import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
 import static org.kiwiproject.base.KiwiStrings.f;
 import static org.kiwiproject.metrics.health.HealthCheckResults.newResultBuilder;
 import static org.kiwiproject.metrics.health.HealthCheckResults.newUnhealthyResult;
@@ -11,12 +12,20 @@ import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.Document;
 
+import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Health check that attempts to issue a 'ping' command to a Mongo database.
+ * <p>
+ * A configurable timeout (default: {@link #DEFAULT_TIMEOUT}) is applied to each ping
+ * via the MongoDB driver's Client-Side Operations Timeout (CSOT). This bounds the
+ * entire operation, including server selection, so that a completely unreachable cluster
+ * does not block the health check thread indefinitely.
  *
  * @see <a href="https://www.mongodb.com/docs/manual/reference/command/ping/">mongo ping command</a>
+ * @see <a href="https://www.mongodb.com/docs/drivers/java/sync/current/fundamentals/csot/">CSOT</a>
  */
 @Slf4j
 public class MongoHealthCheck extends HealthCheck {
@@ -29,12 +38,40 @@ public class MongoHealthCheck extends HealthCheck {
     @SuppressWarnings("unused")
     public static final String DEFAULT_NAME = "Mongo";
 
+    /**
+     * The default timeout applied to each ping command.
+     */
+    public static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
+
     private final MongoDatabase database;
     private final String dbName;
 
+    /**
+     * Creates a new instance that uses {@link #DEFAULT_TIMEOUT} for each ping.
+     *
+     * @param database the Mongo database to ping
+     */
     public MongoHealthCheck(MongoDatabase database) {
-        this.database = database;
+        this(database, DEFAULT_TIMEOUT);
+    }
+
+    /**
+     * Creates a new instance with a custom timeout for each ping.
+     * <p>
+     * The timeout is applied via the MongoDB driver's Client-Side Operations Timeout
+     * (CSOT) and covers the full operation including server selection. When Mongo is
+     * completely unreachable the health check will return unhealthy after at most
+     * {@code timeout} rather than blocking for the driver's default
+     * {@code serverSelectionTimeoutMS} (30 seconds).
+     *
+     * @param database the Mongo database to ping
+     * @param timeout  maximum time to wait for the ping to complete; must be positive
+     */
+    public MongoHealthCheck(MongoDatabase database, Duration timeout) {
+        requireNotNull(database, "database must not be null");
+        requireNotNull(timeout, "timeout must not be null");
         this.dbName = database.getName();
+        this.database = database.withTimeout(timeout.toMillis(), TimeUnit.MILLISECONDS);
     }
 
     /**

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/MongoHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/MongoHealthCheck.java
@@ -3,9 +3,9 @@ package org.kiwiproject.dropwizard.util.health;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
 import static org.kiwiproject.base.KiwiStrings.f;
-import static org.kiwiproject.time.KiwiDurations.isPositive;
 import static org.kiwiproject.metrics.health.HealthCheckResults.newResultBuilder;
 import static org.kiwiproject.metrics.health.HealthCheckResults.newUnhealthyResult;
+import static org.kiwiproject.time.KiwiDurations.isPositive;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.mongodb.client.MongoDatabase;

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/MongoHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/MongoHealthCheck.java
@@ -1,7 +1,9 @@
 package org.kiwiproject.dropwizard.util.health;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
 import static org.kiwiproject.base.KiwiStrings.f;
+import static org.kiwiproject.time.KiwiDurations.isPositive;
 import static org.kiwiproject.metrics.health.HealthCheckResults.newResultBuilder;
 import static org.kiwiproject.metrics.health.HealthCheckResults.newUnhealthyResult;
 
@@ -70,6 +72,7 @@ public class MongoHealthCheck extends HealthCheck {
     public MongoHealthCheck(MongoDatabase database, Duration timeout) {
         requireNotNull(database, "database must not be null");
         requireNotNull(timeout, "timeout must not be null");
+        checkArgument(isPositive(timeout), "timeout must be positive, but was: %s", timeout);
         this.dbName = database.getName();
         this.database = database.withTimeout(timeout.toMillis(), TimeUnit.MILLISECONDS);
     }

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/MongoHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/MongoHealthCheck.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
  * does not block the health check thread indefinitely.
  *
  * @see <a href="https://www.mongodb.com/docs/manual/reference/command/ping/">mongo ping command</a>
- * @see <a href="https://www.mongodb.com/docs/drivers/java/sync/current/fundamentals/csot/">CSOT</a>
+ * @see <a href="https://www.mongodb.com/docs/drivers/java/sync/current/connection/specify-connection-options/csot/">CSOT</a>
  */
 @Slf4j
 public class MongoHealthCheck extends HealthCheck {

--- a/src/test/java/org/kiwiproject/dropwizard/util/health/MongoHealthCheckTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/health/MongoHealthCheckTest.java
@@ -1,9 +1,11 @@
 package org.kiwiproject.dropwizard.util.health;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.kiwiproject.base.KiwiStrings.f;
 import static org.kiwiproject.test.assertj.dropwizard.metrics.HealthCheckResultAssertions.assertThatHealthCheck;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -22,8 +24,10 @@ import org.kiwiproject.metrics.health.HealthStatus;
 import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.OngoingStubbing;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 @DisplayName("MongoHealthCheck")
 class MongoHealthCheckTest {
@@ -33,6 +37,38 @@ class MongoHealthCheckTest {
     private static final String ERROR_MESSAGE_PROPERTY = "errmsg";
     private static final String CODE_PROPERTY = "code";
     private static final String CODE_NAME_PROPERTY = "codeName";
+
+    @Nested
+    class Constructors {
+
+        @Test
+        void defaultConstructorUsesDefaultTimeout() {
+            var database = setupMockMongoDatabase();
+            new MongoHealthCheck(database);
+            verify(database).withTimeout(MongoHealthCheck.DEFAULT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        }
+
+        @Test
+        void customTimeoutConstructorAppliesTimeout() {
+            var database = setupMockMongoDatabase();
+            var timeout = Duration.ofSeconds(10);
+            new MongoHealthCheck(database, timeout);
+            verify(database).withTimeout(timeout.toMillis(), TimeUnit.MILLISECONDS);
+        }
+
+        @Test
+        void throwsWhenDatabaseIsNull() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new MongoHealthCheck(null));
+        }
+
+        @Test
+        void throwsWhenTimeoutIsNull() {
+            var database = setupMockMongoDatabase();
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new MongoHealthCheck(database, null));
+        }
+    }
 
     @Nested
     class IsHealthy {
@@ -103,6 +139,7 @@ class MongoHealthCheckTest {
     private static MongoDatabase setupMockMongoDatabase() {
         var mockDatabase = mock(MongoDatabase.class);
         when(mockDatabase.getName()).thenReturn(DB_NAME);
+        when(mockDatabase.withTimeout(anyLong(), any(TimeUnit.class))).thenReturn(mockDatabase);
         return mockDatabase;
     }
 

--- a/src/test/java/org/kiwiproject/dropwizard/util/health/MongoHealthCheckTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/health/MongoHealthCheckTest.java
@@ -59,14 +59,33 @@ class MongoHealthCheckTest {
         @Test
         void throwsWhenDatabaseIsNull() {
             assertThatIllegalArgumentException()
-                    .isThrownBy(() -> new MongoHealthCheck(null));
+                    .isThrownBy(() -> new MongoHealthCheck(null))
+                    .withMessage("database must not be null");
         }
 
         @Test
         void throwsWhenTimeoutIsNull() {
             var database = setupMockMongoDatabase();
             assertThatIllegalArgumentException()
-                    .isThrownBy(() -> new MongoHealthCheck(database, null));
+                    .isThrownBy(() -> new MongoHealthCheck(database, null))
+                    .withMessage("timeout must not be null");
+        }
+
+        @Test
+        void throwsWhenTimeoutIsZero() {
+            var database = setupMockMongoDatabase();
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new MongoHealthCheck(database, Duration.ZERO))
+                    .withMessage("timeout must be positive, but was: %s", Duration.ZERO);
+        }
+
+        @Test
+        void throwsWhenTimeoutIsNegative() {
+            var database = setupMockMongoDatabase();
+            var timeout = Duration.ofSeconds(-1);
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new MongoHealthCheck(database, timeout))
+                    .withMessage("timeout must be positive, but was: %s", timeout);
         }
     }
 


### PR DESCRIPTION
Without a timeout, MongoHealthCheck.check() blocks for up to 30 seconds (the MongoDB
driver default serverSelectionTimeoutMS) when a cluster is completely unreachable.
During a 3-node cluster maintenance window this caused noticeable disruption on every
health check cycle.

Applied the MongoDB driver's Client-Side Operations Timeout (CSOT) via
MongoDatabase.withTimeout(), which bounds the full operation including server selection.
Added a DEFAULT_TIMEOUT constant of 5 seconds and a new
MongoHealthCheck(MongoDatabase, Duration) constructor for callers that need a different
value. The existing single-argument constructor delegates to the new one.

The new public constructor is backward-compatible new API, so this is a minor version
bump (5.0.x -> 5.1.0).

Closes #653
Closes #655 