### PR TITLE
Add ExecuteJobTask for on-demand execution of long-running jobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <!-- Versions for required dependencies -->
         <dropwizard-curator.version>3.0.2</dropwizard-curator.version>
         <kiwi.version>5.2.0</kiwi.version>
+        <kiwi-beta.version>3.0.2</kiwi-beta.version>
         <kiwi-bom.version>3.1.0</kiwi-bom.version>
         <metrics-healthchecks-severity.version>3.0.2</metrics-healthchecks-severity.version>
         <service-discovery-client.version>3.0.2</service-discovery-client.version>
@@ -67,6 +68,12 @@
                 <groupId>org.kiwiproject</groupId>
                 <artifactId>kiwi</artifactId>
                 <version>${kiwi.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.kiwiproject</groupId>
+                <artifactId>kiwi-beta</artifactId>
+                <version>${kiwi-beta.version}</version>
             </dependency>
 
             <dependency>
@@ -120,6 +127,11 @@
         <dependency>
             <groupId>org.kiwiproject</groupId>
             <artifactId>kiwi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.kiwiproject</groupId>
+            <artifactId>kiwi-beta</artifactId>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTask.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTask.java
@@ -54,6 +54,10 @@ import java.util.function.Supplier;
  * at {@code POST /tasks/dataSyncJob}.
  * <p>
  * Requires an {@link ExecuteJobTaskConfig}.
+ *
+ * @implNote Truthy value parsing is delegated to {@code BooleanUtils.toBoolean(String)} from
+ * Apache Commons Lang. The five values listed above are the documented contract; if the
+ * library's behavior changes, the implementation should be updated to preserve them.
  */
 @Slf4j
 public class ExecuteJobTask extends Task {

--- a/src/main/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTask.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTask.java
@@ -1,0 +1,204 @@
+package org.kiwiproject.dropwizard.util.task;
+
+import static java.util.Objects.nonNull;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+import static org.kiwiproject.base.KiwiPreconditions.requireNotBlank;
+import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
+import static org.kiwiproject.base.KiwiStrings.f;
+import static org.kiwiproject.base.UUIDs.randomUUIDString;
+import static org.kiwiproject.collect.KiwiLists.first;
+import static org.kiwiproject.time.KiwiDurationFormatters.formatNanosecondDurationWords;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.dropwizard.servlets.tasks.Task;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.text.CaseUtils;
+import org.jspecify.annotations.Nullable;
+import org.kiwiproject.beta.time.Timing;
+import org.kiwiproject.collect.KiwiMaps;
+import org.kiwiproject.concurrent.Async;
+
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+/**
+ * A task that executes a job ({@link Runnable}) on demand, synchronously or asynchronously.
+ * <p>
+ * By default, the job runs asynchronously. Pass a {@code sync} query parameter with a truthy
+ * value (case-insensitive {@code true}, {@code on}, {@code y}, {@code t}, or {@code yes})
+ * to force synchronous execution.
+ * <p>
+ * Only one execution is permitted at a time. If the task is invoked while already running,
+ * the request returns immediately with a message in the task output; the job is not executed.
+ * <p>
+ * The {@link ExecuteJobTaskConfig#canRun()} supplier is consulted before each execution. If
+ * it returns {@code false}, execution is skipped. In that case, if the
+ * {@link ExecuteJobTaskConfig#cannotRunExceptionProvider()} returns a non-null exception,
+ * that exception is thrown; otherwise a message is written to the task output.
+ * <p>
+ * When running asynchronously, an {@code asyncId} is generated and included in both the task
+ * output and all log messages for that execution, providing a correlation handle between the
+ * HTTP response and the application logs.
+ * <p>
+ * If {@code taskName} is not provided, the Dropwizard task name defaults to the camelCase form
+ * of {@code jobName} (e.g., "Data Sync Job" becomes "dataSyncJob"), and the task is accessible
+ * at {@code POST /tasks/dataSyncJob}.
+ * <p>
+ * Requires an {@link ExecuteJobTaskConfig}.
+ */
+@Slf4j
+public class ExecuteJobTask extends Task {
+
+    private final Runnable job;
+    private final String jobName;
+    private final BooleanSupplier canRun;
+    private final Supplier<@Nullable Exception> cannotRunExceptionProvider;
+    private final ExecutorService executorService;
+
+    @VisibleForTesting
+    final AtomicBoolean running;
+
+    /**
+     * Create a new instance using the builder.
+     *
+     * @param job        the job to execute; required
+     * @param jobName    a human-readable name for the job, used in log and output messages; required
+     * @param taskName   the Dropwizard task name used in the {@code POST /tasks/{taskName}} URL;
+     *                   if blank, defaults to the camelCase form of {@code jobName}
+     * @param taskConfig configuration controlling execution behavior; required
+     */
+    @Builder
+    public ExecuteJobTask(Runnable job,
+                          String jobName,
+                          String taskName,
+                          ExecuteJobTaskConfig taskConfig) {
+
+        super(taskNameOrDefault(taskName, jobName));
+
+        this.job = requireNotNull(job, "job must not be null");
+        this.jobName = requireNotBlank(jobName, "jobName must not be blank");
+
+        checkArgumentNotNull(taskConfig, "taskConfig must not be null");
+        this.canRun = taskConfig.canRun();
+        this.cannotRunExceptionProvider = taskConfig.cannotRunExceptionProvider();
+        this.executorService = taskConfig.executorService();
+
+        this.running = new AtomicBoolean(false);
+    }
+
+    @VisibleForTesting
+    static String taskNameOrDefault(@Nullable String taskName, String jobName) {
+        if (isNotBlank(taskName)) {
+            return taskName;
+        }
+
+        checkArgumentNotBlank(jobName, "jobName must not be blank");
+        return CaseUtils.toCamelCase(jobName, false);
+    }
+
+    @Override
+    public void execute(Map<String, List<String>> parameters, PrintWriter output) throws Exception {
+        if (!running.compareAndSet(false, true)) {
+            var message = f("Task for {} is already running. Skipping.", jobName);
+            LOG.warn(message);
+            output.println(message);
+            return;
+        }
+
+        try {
+            if (!canRun.getAsBoolean()) {
+                running.set(false);
+
+                var ex = cannotRunExceptionProvider.get();
+                if (nonNull(ex)) {
+                    throw ex;
+                }
+
+                var message = f("Not executing {} (canRun returned false)", jobName);
+                LOG.info(message);
+                output.println(message);
+                return;
+            }
+
+            var sync = isSync(parameters);
+
+            if (sync) {
+                runJobSync(output);
+            } else {
+                runJobAsync(output);
+            }
+        } catch (Exception e) {
+            running.set(false);
+            throw e;
+        }
+    }
+
+    private boolean isSync(Map<String, List<String>> parameters) {
+        var syncParamValues = KiwiMaps.getTypedList(parameters, "sync", String.class, List.of("false"));
+
+        //noinspection DataFlowIssue - because we are providing a non-null default value, it won't be null
+        return BooleanUtils.toBoolean(first(syncParamValues));
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    private void runJobSync(PrintWriter output) {
+        try {
+            LOG.info("Executing {} synchronously", jobName);
+
+            var result = Timing.timeNoResult(job);
+            var durationInWords = formatNanosecondDurationWords(result.getElapsedNanos());
+
+            if (result.hasException()) {
+                var ex = result.getException().orElseThrow();
+                LOG.error("Failed executing {} with exception in {}", jobName, durationInWords, ex);
+                throw ex;
+            }
+
+            output.println(f("Successfully executed {} in {}", jobName, durationInWords));
+        } finally {
+            running.set(false);
+        }
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    private void runJobAsync(PrintWriter output) {
+        var asyncId = randomUUIDString();
+        LOG.info("Executing {} asynchronously with asyncId {}", jobName, asyncId);
+
+        try {
+            Async.runAsync(() -> {
+                try {
+                    var result = Timing.timeNoResult(job);
+                    var durationInWords = formatNanosecondDurationWords(result.getElapsedNanos());
+
+                    if (result.hasException()) {
+                        var ex = result.getException().orElseThrow();
+                        LOG.error("Failed executing {} with exception in {} (asyncId: {})",
+                                jobName, durationInWords, asyncId, ex);
+                    } else {
+                        LOG.info("Successfully executed {} in {} (asyncId: {})",
+                                jobName, durationInWords, asyncId);
+                    }
+                } finally {
+                    running.set(false);
+                }
+            }, executorService);
+        } catch (RuntimeException e) {  // handle runtime exceptions, e.g., a RejectedExecutionException
+            LOG.error("Failed to submit async execution of {}", jobName, e);
+            running.set(false);
+            throw e;
+        }
+
+        output.println(f("Started executing {} in background (asyncId: {}). Logs will contain results after completion.",
+                jobName, asyncId));
+    }
+}

--- a/src/main/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTaskConfig.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTaskConfig.java
@@ -42,7 +42,7 @@ public class ExecuteJobTaskConfig {
                          ExecutorService executorService) {
         this.canRun = isNull(canRun) ? () -> true : canRun;
         this.cannotRunExceptionProvider = isNull(cannotRunExceptionProvider) ? () -> null : cannotRunExceptionProvider;
-        this.executorService = requireNotNull(executorService);
+        this.executorService = requireNotNull(executorService, "executorService must not be null");
     }
 
     /**

--- a/src/main/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTaskConfig.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTaskConfig.java
@@ -13,7 +13,18 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
 /**
- * Configuration for {@link ExecuteJobTask}.
+ * Configuration for {@link ExecuteJobTask}, controlling whether and how the job executes.
+ * <p>
+ * The {@code canRun} supplier is consulted before each execution; it defaults to always
+ * returning {@code true}. The {@code cannotRunExceptionProvider} optionally supplies an
+ * exception to throw when {@code canRun} returns {@code false}; it defaults to returning
+ * {@code null}, meaning execution is silently skipped with a message written to the task
+ * output. The {@code executorService} is required and used for async execution; it should
+ * be externally managed (e.g., via Dropwizard's lifecycle).
+ * <p>
+ * Use {@link #canAlwaysRun(ExecutorService)} for the common case where the job should
+ * always run, or {@link #canRunWhen(BooleanSupplier, ExecutorService)} to supply a
+ * custom condition. Use the builder for full control over all three options.
  */
 @Getter
 @Accessors(fluent = true)

--- a/src/main/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTaskConfig.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTaskConfig.java
@@ -1,0 +1,82 @@
+package org.kiwiproject.dropwizard.util.task;
+
+import static java.util.Objects.isNull;
+import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+import org.jspecify.annotations.Nullable;
+
+import java.util.concurrent.ExecutorService;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+/**
+ * Configuration for {@link ExecuteJobTask}.
+ */
+@Getter
+@Accessors(fluent = true)
+@SuppressWarnings("ClassCanBeRecord")
+public class ExecuteJobTaskConfig {
+
+    private final BooleanSupplier canRun;
+    private final Supplier<@Nullable Exception> cannotRunExceptionProvider;
+    private final ExecutorService executorService;
+
+    /**
+     * Create a new instance.
+     *
+     * @param canRun                     provides a boolean that determines whether the task is allowed to run;
+     *                                   if not given, the default value is true
+     * @param cannotRunExceptionProvider a Supplier that can optionally provide an exception to be thrown if
+     *                                   the task is not allowed to run; if not given, the default value
+     *                                   always returns null, meaning no exception would be thrown
+     * @param executorService            a required {@link ExecutorService} used for async task execution;
+     *                                   this should be externally managed, e.g., building one using
+     *                                   {@link io.dropwizard.lifecycle.setup.LifecycleEnvironment#executorService(String)}
+     */
+    @Builder
+    ExecuteJobTaskConfig(@Nullable BooleanSupplier canRun,
+                         @Nullable Supplier<@Nullable Exception> cannotRunExceptionProvider,
+                         ExecutorService executorService) {
+        this.canRun = isNull(canRun) ? () -> true : canRun;
+        this.cannotRunExceptionProvider = isNull(cannotRunExceptionProvider) ? () -> null : cannotRunExceptionProvider;
+        this.executorService = requireNotNull(executorService);
+    }
+
+    /**
+     * Factory to create a configuration that is always allowed to run.
+     *
+     * @param executorService a required {@link ExecutorService} used for async task execution;
+     *                        this should be externally managed
+     * @return a new instance
+     */
+    public static ExecuteJobTaskConfig canAlwaysRun(ExecutorService executorService) {
+        return ExecuteJobTaskConfig.builder()
+                .canRun(() -> true)
+                .executorService(executorService)
+                .build();
+    }
+
+    /**
+     * Factory to create a configuration with a custom condition controlling whether the task
+     * is allowed to run. If the condition returns {@code false}, a message is written to the
+     * task output and execution is skipped without throwing an exception.
+     * <p>
+     * A common use case is leader election: pass a supplier that checks whether this service
+     * instance holds the leader latch, so the job only executes on the elected leader.
+     *
+     * @param canRun          a supplier that determines whether the task is allowed to run
+     * @param executorService a required {@link ExecutorService} used for async task execution;
+     *                        this should be externally managed
+     * @return a new instance
+     */
+    public static ExecuteJobTaskConfig canRunWhen(BooleanSupplier canRun, ExecutorService executorService) {
+        requireNotNull(canRun, "canRun must not be null");
+        return ExecuteJobTaskConfig.builder()
+                .canRun(canRun)
+                .executorService(executorService)
+                .build();
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTaskConfigTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTaskConfigTest.java
@@ -1,0 +1,154 @@
+package org.kiwiproject.dropwizard.util.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@DisplayName("ExecuteJobTaskConfig")
+class ExecuteJobTaskConfigTest {
+
+    @Nested
+    class Builder {
+
+        private ExecutorService executor;
+
+        @BeforeEach
+        void setUp() {
+            executor = Executors.newSingleThreadExecutor();
+        }
+
+        @AfterEach
+        void tearDown() {
+            executor.shutdownNow();
+        }
+
+        @Test
+        void shouldRequireExecutorService() {
+            var builder = ExecuteJobTaskConfig.builder();
+            assertThatThrownBy(builder::build)
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void shouldDefaultCanRunToAlwaysTrue() {
+            var config = ExecuteJobTaskConfig.builder()
+                    .executorService(executor)
+                    .build();
+            assertThat(config.canRun().getAsBoolean()).isTrue();
+        }
+
+        @Test
+        void shouldDefaultCannotRunExceptionProviderToReturnsNull() {
+            var config = ExecuteJobTaskConfig.builder()
+                    .executorService(executor)
+                    .build();
+            assertThat(config.cannotRunExceptionProvider().get()).isNull();
+        }
+
+        @Test
+        void shouldAcceptCustomCanRun() {
+            var config = ExecuteJobTaskConfig.builder()
+                    .canRun(() -> false)
+                    .executorService(executor)
+                    .build();
+            assertThat(config.canRun().getAsBoolean()).isFalse();
+        }
+
+        @Test
+        void shouldAcceptCustomCannotRunExceptionProvider() {
+            var ex = new IllegalStateException("not allowed");
+            var config = ExecuteJobTaskConfig.builder()
+                    .cannotRunExceptionProvider(() -> ex)
+                    .executorService(executor)
+                    .build();
+            assertThat(config.cannotRunExceptionProvider().get()).isSameAs(ex);
+        }
+
+        @Test
+        void shouldUseProvidedExecutorService() {
+            var config = ExecuteJobTaskConfig.builder()
+                    .executorService(executor)
+                    .build();
+            assertThat(config.executorService()).isSameAs(executor);
+        }
+    }
+
+    @Nested
+    class CanAlwaysRun {
+
+        private ExecutorService executor;
+
+        @BeforeEach
+        void setUp() {
+            executor = Executors.newSingleThreadExecutor();
+        }
+
+        @AfterEach
+        void tearDown() {
+            executor.shutdownNow();
+        }
+
+        @Test
+        void shouldRequireExecutorService() {
+            assertThatThrownBy(() -> ExecuteJobTaskConfig.canAlwaysRun(null))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void shouldCreateConfigThatAlwaysRunsWithNoExceptionAndCorrectExecutor() {
+            var config = ExecuteJobTaskConfig.canAlwaysRun(executor);
+            assertAll(
+                    () -> assertThat(config.canRun().getAsBoolean()).isTrue(),
+                    () -> assertThat(config.cannotRunExceptionProvider().get()).isNull(),
+                    () -> assertThat(config.executorService()).isSameAs(executor)
+            );
+        }
+    }
+
+    @Nested
+    class CanRunWhen {
+
+        private ExecutorService executor;
+
+        @BeforeEach
+        void setUp() {
+            executor = Executors.newSingleThreadExecutor();
+        }
+
+        @AfterEach
+        void tearDown() {
+            executor.shutdownNow();
+        }
+
+        @Test
+        void shouldRequireCanRun() {
+            assertThatThrownBy(() -> ExecuteJobTaskConfig.canRunWhen(null, executor))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void shouldRequireExecutorService() {
+            assertThatThrownBy(() -> ExecuteJobTaskConfig.canRunWhen(() -> true, null))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void shouldUseProvidedCanRunCondition() {
+            var config = ExecuteJobTaskConfig.canRunWhen(() -> false, executor);
+            assertAll(
+                    () -> assertThat(config.canRun().getAsBoolean()).isFalse(),
+                    () -> assertThat(config.cannotRunExceptionProvider().get()).isNull(),
+                    () -> assertThat(config.executorService()).isSameAs(executor)
+            );
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTaskTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTaskTest.java
@@ -172,7 +172,7 @@ class ExecuteJobTaskTest {
         }
 
         private String outputText() {
-            return stringWriter.toString();
+            return stringWriter.toString().trim();
         }
 
         @Nested
@@ -188,7 +188,7 @@ class ExecuteJobTaskTest {
 
                 assertAll(
                         () -> assertThat(jobRan.get()).isFalse(),
-                        () -> assertThat(outputText()).contains("already running"),
+                        () -> assertThat(outputText()).isEqualTo("Task for Test Job is already running. Skipping."),
                         () -> assertThat(task.running.get()).isTrue()
                 );
             }
@@ -211,7 +211,7 @@ class ExecuteJobTaskTest {
                 task.execute(Map.of(), output);
 
                 assertAll(
-                        () -> assertThat(outputText()).contains("Not executing"),
+                        () -> assertThat(outputText()).isEqualTo("Not executing Test Job (canRun returned false)"),
                         () -> assertThat(task.running.get()).isFalse()
                 );
             }
@@ -264,7 +264,7 @@ class ExecuteJobTaskTest {
 
                 assertAll(
                         () -> assertThat(jobRan.get()).isTrue(),
-                        () -> assertThat(outputText()).contains("Successfully executed"),
+                        () -> assertThat(outputText()).startsWith("Successfully executed Test Job in "),
                         () -> assertThat(task.running.get()).isFalse()
                 );
             }
@@ -279,7 +279,7 @@ class ExecuteJobTaskTest {
 
                 assertAll(
                         () -> assertThat(jobRan.get()).isTrue(),
-                        () -> assertThat(outputText()).contains("Successfully executed")
+                        () -> assertThat(outputText()).startsWith("Successfully executed Test Job in ")
                 );
             }
 
@@ -289,7 +289,7 @@ class ExecuteJobTaskTest {
 
                 task.execute(Map.of(), output);
 
-                assertThat(outputText()).contains("in background");
+                assertThat(outputText()).startsWith("Started executing Test Job in background (asyncId: ");
             }
 
             @Test
@@ -298,7 +298,7 @@ class ExecuteJobTaskTest {
 
                 task.execute(Map.of("sync", List.of("false")), output);
 
-                assertThat(outputText()).contains("in background");
+                assertThat(outputText()).startsWith("Started executing Test Job in background (asyncId: ");
             }
 
             @Test
@@ -324,7 +324,7 @@ class ExecuteJobTaskTest {
 
                 assertAll(
                         () -> assertThat(jobRan.get()).isTrue(),
-                        () -> assertThat(outputText()).contains("in background").contains("asyncId"),
+                        () -> assertThat(outputText()).startsWith("Started executing Test Job in background (asyncId: "),
                         () -> assertThat(task.running.get()).isFalse()
                 );
             }
@@ -337,7 +337,7 @@ class ExecuteJobTaskTest {
                         .doesNotThrowAnyException();
 
                 assertAll(
-                        () -> assertThat(outputText()).contains("in background"),
+                        () -> assertThat(outputText()).startsWith("Started executing Test Job in background (asyncId: "),
                         () -> assertThat(task.running.get()).isFalse()
                 );
             }

--- a/src/test/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTaskTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTaskTest.java
@@ -172,7 +172,7 @@ class ExecuteJobTaskTest {
         }
 
         private String outputText() {
-            return stringWriter.toString().trim();
+            return stringWriter.toString().strip();
         }
 
         @Nested

--- a/src/test/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTaskTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTaskTest.java
@@ -46,6 +46,16 @@ class ExecuteJobTaskTest {
         }
 
         @ClearBoxTest
+        void shouldDeriveTaskNameFromJobNameWithMultipleSpaces() {
+            assertThat(ExecuteJobTask.taskNameOrDefault(null, "Execute  My  Job")).isEqualTo("executeMyJob");
+        }
+
+        @ClearBoxTest
+        void shouldDeriveTaskNameFromJobNameWithLeadingAndTrailingSpaces() {
+            assertThat(ExecuteJobTask.taskNameOrDefault(null, "  Execute My Job  ")).isEqualTo("executeMyJob");
+        }
+
+        @ClearBoxTest
         void shouldThrowWhenTaskNameIsBlankAndJobNameIsBlank() {
             assertThatThrownBy(() -> ExecuteJobTask.taskNameOrDefault("  ", "  "))
                     .isInstanceOf(IllegalArgumentException.class);

--- a/src/test/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTaskTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTaskTest.java
@@ -1,0 +1,352 @@
+package org.kiwiproject.dropwizard.util.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.kiwiproject.test.junit.jupiter.AsyncModeDisablingExtension;
+import org.kiwiproject.test.junit.jupiter.ClearBoxTest;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@DisplayName("ExecuteJobTask")
+class ExecuteJobTaskTest {
+
+    @Nested
+    class TaskNameOrDefault {
+
+        @ClearBoxTest
+        void shouldReturnProvidedTaskName() {
+            assertThat(ExecuteJobTask.taskNameOrDefault("myTask", "Some Job")).isEqualTo("myTask");
+        }
+
+        @ClearBoxTest
+        void shouldDeriveTaskNameFromJobNameWhenTaskNameIsNull() {
+            assertThat(ExecuteJobTask.taskNameOrDefault(null, "Execute My Job")).isEqualTo("executeMyJob");
+        }
+
+        @ClearBoxTest
+        void shouldDeriveTaskNameFromJobNameWhenTaskNameIsBlank() {
+            assertThat(ExecuteJobTask.taskNameOrDefault("  ", "Execute My Job")).isEqualTo("executeMyJob");
+        }
+
+        @ClearBoxTest
+        void shouldThrowWhenTaskNameIsBlankAndJobNameIsBlank() {
+            assertThatThrownBy(() -> ExecuteJobTask.taskNameOrDefault("  ", "  "))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @ClearBoxTest
+        void shouldThrowWhenTaskNameIsNullAndJobNameIsBlank() {
+            assertThatThrownBy(() -> ExecuteJobTask.taskNameOrDefault(null, ""))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    class Construction {
+
+        private ExecutorService executor;
+
+        @BeforeEach
+        void setUp() {
+            executor = Executors.newSingleThreadExecutor();
+        }
+
+        @AfterEach
+        void tearDown() {
+            executor.shutdownNow();
+        }
+
+        @Test
+        void shouldBuildSuccessfully() {
+            assertThatCode(() -> ExecuteJobTask.builder()
+                    .job(() -> {})
+                    .jobName("Test Job")
+                    .taskConfig(ExecuteJobTaskConfig.canAlwaysRun(executor))
+                    .build())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldDeriveTaskNameFromJobNameAsCamelCase() {
+            var task = ExecuteJobTask.builder()
+                    .job(() -> {})
+                    .jobName("Execute My Job")
+                    .taskConfig(ExecuteJobTaskConfig.canAlwaysRun(executor))
+                    .build();
+            assertThat(task.getName()).isEqualTo("executeMyJob");
+        }
+
+        @Test
+        void shouldUseProvidedTaskName() {
+            var task = ExecuteJobTask.builder()
+                    .job(() -> {})
+                    .jobName("Execute My Job")
+                    .taskName("custom-task")
+                    .taskConfig(ExecuteJobTaskConfig.canAlwaysRun(executor))
+                    .build();
+            assertThat(task.getName()).isEqualTo("custom-task");
+        }
+
+        @Test
+        void shouldRequireJob() {
+            var builder = ExecuteJobTask.builder()
+                    .jobName("Test Job")
+                    .taskConfig(ExecuteJobTaskConfig.canAlwaysRun(executor));
+            assertThatThrownBy(builder::build)
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void shouldRequireJobName() {
+            var builder = ExecuteJobTask.builder()
+                    .job(() -> {})
+                    .taskName("my-task")
+                    .taskConfig(ExecuteJobTaskConfig.canAlwaysRun(executor));
+            assertThatThrownBy(builder::build)
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void shouldRequireTaskConfig() {
+            var builder = ExecuteJobTask.builder()
+                    .job(() -> {})
+                    .jobName("Test Job");
+            assertThatThrownBy(builder::build)
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @ExtendWith(AsyncModeDisablingExtension.class)
+    class Execute {
+
+        private ExecutorService executor;
+        private StringWriter stringWriter;
+        private PrintWriter output;
+
+        @BeforeEach
+        void setUp() {
+            executor = Executors.newSingleThreadExecutor();
+            stringWriter = new StringWriter();
+            output = new PrintWriter(stringWriter);
+        }
+
+        @AfterEach
+        void tearDown() {
+            executor.shutdownNow();
+        }
+
+        private ExecuteJobTask buildTask(Runnable job) {
+            return ExecuteJobTask.builder()
+                    .job(job)
+                    .jobName("Test Job")
+                    .taskConfig(ExecuteJobTaskConfig.canAlwaysRun(executor))
+                    .build();
+        }
+
+        private String outputText() {
+            return stringWriter.toString();
+        }
+
+        @Nested
+        class WhenAlreadyRunning {
+
+            @Test
+            void shouldSkipJobAndPrintAlreadyRunningMessage() throws Exception {
+                var jobRan = new AtomicBoolean();
+                var task = buildTask(() -> jobRan.set(true));
+                task.running.set(true);
+
+                task.execute(Map.of(), output);
+
+                assertAll(
+                        () -> assertThat(jobRan.get()).isFalse(),
+                        () -> assertThat(outputText()).contains("already running"),
+                        () -> assertThat(task.running.get()).isTrue()
+                );
+            }
+        }
+
+        @Nested
+        class WhenCannotRun {
+
+            @Test
+            void shouldPrintMessageAndResetRunning() throws Exception {
+                var task = ExecuteJobTask.builder()
+                        .job(() -> {})
+                        .jobName("Test Job")
+                        .taskConfig(ExecuteJobTaskConfig.builder()
+                                .canRun(() -> false)
+                                .executorService(executor)
+                                .build())
+                        .build();
+
+                task.execute(Map.of(), output);
+
+                assertAll(
+                        () -> assertThat(outputText()).contains("Not executing"),
+                        () -> assertThat(task.running.get()).isFalse()
+                );
+            }
+
+            @Test
+            void shouldThrowProvidedExceptionAndResetRunning() {
+                var ex = new IllegalStateException("not the leader");
+                var task = ExecuteJobTask.builder()
+                        .job(() -> {})
+                        .jobName("Test Job")
+                        .taskConfig(ExecuteJobTaskConfig.builder()
+                                .canRun(() -> false)
+                                .cannotRunExceptionProvider(() -> ex)
+                                .executorService(executor)
+                                .build())
+                        .build();
+
+                assertThatThrownBy(() -> task.execute(Map.of(), output))
+                        .isSameAs(ex);
+                assertThat(task.running.get()).isFalse();
+            }
+
+            @Test
+            void shouldResetRunningAndRethrowWhenCanRunThrows() {
+                var cause = new RuntimeException("canRun exploded");
+                var task = ExecuteJobTask.builder()
+                        .job(() -> {})
+                        .jobName("Test Job")
+                        .taskConfig(ExecuteJobTaskConfig.builder()
+                                .canRun(() -> { throw cause; })
+                                .executorService(executor)
+                                .build())
+                        .build();
+
+                assertThatThrownBy(() -> task.execute(Map.of(), output))
+                        .isSameAs(cause);
+                assertThat(task.running.get()).isFalse();
+            }
+        }
+
+        @Nested
+        class Synchronous {
+
+            @Test
+            void shouldExecuteJobAndPrintSuccessMessage() throws Exception {
+                var jobRan = new AtomicBoolean();
+                var task = buildTask(() -> jobRan.set(true));
+
+                task.execute(Map.of("sync", List.of("true")), output);
+
+                assertAll(
+                        () -> assertThat(jobRan.get()).isTrue(),
+                        () -> assertThat(outputText()).contains("Successfully executed"),
+                        () -> assertThat(task.running.get()).isFalse()
+                );
+            }
+
+            @ParameterizedTest
+            @ValueSource(strings = {"true", "on", "y", "t", "yes", "True", "YES", "ON"})
+            void shouldTreatAllDocumentedTruthyValuesAsSynchronous(String syncValue) throws Exception {
+                var jobRan = new AtomicBoolean();
+                var task = buildTask(() -> jobRan.set(true));
+
+                task.execute(Map.of("sync", List.of(syncValue)), output);
+
+                assertAll(
+                        () -> assertThat(jobRan.get()).isTrue(),
+                        () -> assertThat(outputText()).contains("Successfully executed")
+                );
+            }
+
+            @Test
+            void shouldDefaultToAsyncWhenSyncParamIsAbsent() throws Exception {
+                var task = buildTask(() -> {});
+
+                task.execute(Map.of(), output);
+
+                assertThat(outputText()).contains("in background");
+            }
+
+            @Test
+            void shouldDefaultToAsyncWhenSyncParamIsFalse() throws Exception {
+                var task = buildTask(() -> {});
+
+                task.execute(Map.of("sync", List.of("false")), output);
+
+                assertThat(outputText()).contains("in background");
+            }
+
+            @Test
+            void shouldThrowJobExceptionAndResetRunning() {
+                var ex = new RuntimeException("job failed");
+                var task = buildTask(() -> { throw ex; });
+
+                assertThatThrownBy(() -> task.execute(Map.of("sync", List.of("true")), output))
+                        .isSameAs(ex);
+                assertThat(task.running.get()).isFalse();
+            }
+        }
+
+        @Nested
+        class Asynchronous {
+
+            @Test
+            void shouldExecuteJobAndPrintAsyncMessage() throws Exception {
+                var jobRan = new AtomicBoolean();
+                var task = buildTask(() -> jobRan.set(true));
+
+                task.execute(Map.of(), output);
+
+                assertAll(
+                        () -> assertThat(jobRan.get()).isTrue(),
+                        () -> assertThat(outputText()).contains("in background").contains("asyncId"),
+                        () -> assertThat(task.running.get()).isFalse()
+                );
+            }
+
+            @Test
+            void shouldNotThrowAndResetRunningWhenJobThrows() {
+                var task = buildTask(() -> { throw new RuntimeException("async job failed"); });
+
+                assertThatCode(() -> task.execute(Map.of(), output))
+                        .doesNotThrowAnyException();
+
+                assertAll(
+                        () -> assertThat(outputText()).contains("in background"),
+                        () -> assertThat(task.running.get()).isFalse()
+                );
+            }
+
+            @Test
+            void shouldResetRunningAndRethrowWhenExecutorRejectsSubmission() {
+                var rejectedExecutor = Executors.newSingleThreadExecutor();
+                rejectedExecutor.shutdownNow();
+                var task = ExecuteJobTask.builder()
+                        .job(() -> {})
+                        .jobName("Test Job")
+                        .taskConfig(ExecuteJobTaskConfig.canAlwaysRun(rejectedExecutor))
+                        .build();
+
+                var params = Map.<String, List<String>>of();
+                assertThatThrownBy(() -> task.execute(params, output))
+                        .isInstanceOf(RuntimeException.class);
+                assertThat(task.running.get()).isFalse();
+            }
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTaskTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTaskTest.java
@@ -330,7 +330,7 @@ class ExecuteJobTaskTest {
             }
 
             @Test
-            void shouldNotThrowAndResetRunningWhenJobThrows() {
+            void shouldSwallowJobExceptionAndResetRunning() {
                 var task = buildTask(() -> { throw new RuntimeException("async job failed"); });
 
                 assertThatCode(() -> task.execute(Map.of(), output))

--- a/src/test/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTaskTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/task/ExecuteJobTaskTest.java
@@ -284,6 +284,20 @@ class ExecuteJobTaskTest {
             }
 
             @Test
+            void shouldThrowJobExceptionAndResetRunning() {
+                var ex = new RuntimeException("job failed");
+                var task = buildTask(() -> { throw ex; });
+
+                assertThatThrownBy(() -> task.execute(Map.of("sync", List.of("true")), output))
+                        .isSameAs(ex);
+                assertThat(task.running.get()).isFalse();
+            }
+        }
+
+        @Nested
+        class Asynchronous {
+
+            @Test
             void shouldDefaultToAsyncWhenSyncParamIsAbsent() throws Exception {
                 var task = buildTask(() -> {});
 
@@ -300,20 +314,6 @@ class ExecuteJobTaskTest {
 
                 assertThat(outputText()).startsWith("Started executing Test Job in background (asyncId: ");
             }
-
-            @Test
-            void shouldThrowJobExceptionAndResetRunning() {
-                var ex = new RuntimeException("job failed");
-                var task = buildTask(() -> { throw ex; });
-
-                assertThatThrownBy(() -> task.execute(Map.of("sync", List.of("true")), output))
-                        .isSameAs(ex);
-                assertThat(task.running.get()).isFalse();
-            }
-        }
-
-        @Nested
-        class Asynchronous {
 
             @Test
             void shouldExecuteJobAndPrintAsyncMessage() throws Exception {


### PR DESCRIPTION
Add ExecuteJobTask (extending Dropwizard's Task) and ExecuteJobTaskConfig to allow a long-running
job (Runnable) to be triggered on demand via the admin task interface.

The motivating use case is a job that runs on a fixed schedule on the leader instance but
occasionally needs to be triggered immediately without waiting for the next scheduled window.

ExecuteJobTask behavior:

- Runs asynchronously by default; pass sync=true (or on, y, t, yes) to force synchronous execution.
- Prevents concurrent execution via an AtomicBoolean guard; if the job is already running, the
  request returns immediately with a message.
- Supports a canRun condition to gate execution (e.g., leader latch check). If canRun returns
  false, execution is skipped with either a message or a caller-supplied exception.
- When running asynchronously, an asyncId is generated and included in both the HTTP response and
  all log messages for that execution, providing a correlation handle between the response and the
  application logs.
- Task name defaults to the camelCase form of jobName when not explicitly provided.

ExecuteJobTaskConfig encapsulates execution configuration (canRun, cannotRunExceptionProvider,
ExecutorService) with canAlwaysRun and canRunWhen factory methods.

Closes #657