### PR TITLE
feat: overlay TLS config on existing HTTPS connectors

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/PortAssigner.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/PortAssigner.java
@@ -136,16 +136,30 @@ public class PortAssigner {
      * If an application is using multiple connectors, it's best to avoid using this class
      * unless you only want the first ones dynamically assigned.
      * <p>
-     * When using {@link PortSecurity#SECURE HTTPS}, the current implementation <strong>replaces</strong> the
-     * application and admin connector factories, which overrides any explicit configuration.
-     * Support for explicit configuration of secure connectors while still assigning dynamics ports may
-     * be implemented in the future if custom configuration is needed.
-     * <p>
-     * <strong>WARNING</strong>: If you need to change specific properties of secure ports
-     * or need more than one secure application and/or admin port, you can't use this
-     * class, since it will replace all other ports!
+     * When using {@link PortSecurity#SECURE HTTPS}, the behavior depends on whether explicit
+     * HTTPS connectors are already configured in the server factory:
+     * <ul>
+     *     <li>
+     *         If the first application <em>and</em> admin connectors are already
+     *         {@link HttpsConnectorFactory} instances (e.g., configured in YAML as
+     *         {@code type: https}), dynamic ports are assigned and TLS properties from the
+     *         {@link TlsContextConfiguration} are overlaid onto the existing connectors.
+     *         All other connector properties (e.g., {@code idleTimeout}, {@code outputBufferSize})
+     *         are preserved from the existing YAML configuration.
+     *     </li>
+     *     <li>
+     *         Otherwise, new {@link HttpsConnectorFactory} instances are created from scratch
+     *         using the {@link TlsContextConfiguration}, replacing any existing connectors.
+     *         This is the default behavior when no explicit server configuration is defined in YAML.
+     *     </li>
+     * </ul>
      *
      * @return the list of ports in the ServerFactory after assigning dynamic ports
+     * @implNote Both the application and admin connectors must be {@link HttpsConnectorFactory}
+     * instances for the overlay path to be taken. If only one is {@code https}, we create new
+     * connectors rather than a partial overlay. We are in {@link PortSecurity#SECURE} mode, and
+     * a partial overlay would produce inconsistent behavior; one connector instance preserved
+     * from YAML while the other is created from scratch.
      */
     public List<Port> assignDynamicPorts() {
         if (portAssignment == PortAssignment.STATIC) {
@@ -154,10 +168,40 @@ public class PortAssigner {
         }
 
         if (portSecurity == PortSecurity.SECURE) {
-            return assignSecureDynamicPortsToNewConnectors();
+            return assignSecureDynamicPorts();
         } else {
             return assignDynamicPortsToExistingConnectors();
         }
+    }
+
+    private List<Port> assignSecureDynamicPorts() {
+        if (first(serverFactory.getApplicationConnectors()) instanceof HttpsConnectorFactory appConnector
+                && first(serverFactory.getAdminConnectors()) instanceof HttpsConnectorFactory adminConnector) {
+            LOG.debug("Found existing HTTPS app/admin connectors; overlaying TLS config and assigning dynamic ports");
+            return overlaySecureDynamicPortsOnExistingConnectors(appConnector, adminConnector);
+        }
+        return assignSecureDynamicPortsToNewConnectors();
+    }
+
+    private List<Port> overlaySecureDynamicPortsOnExistingConnectors(HttpsConnectorFactory appConnector,
+                                                                      HttpsConnectorFactory adminConnector) {
+        var servicePorts = freePortFinder.find(allowablePortRange);
+
+        var appPort = servicePorts.applicationPort();
+        appConnector.setPort(appPort);
+        applyTlsConfiguration(appConnector, tlsConfiguration);
+
+        var adminPort = servicePorts.adminPort();
+        adminConnector.setPort(adminPort);
+        applyTlsConfiguration(adminConnector, tlsConfiguration);
+
+        LOG.info("Assigned application port as {} and admin port as {} to existing HTTPS connectors",
+                appPort, adminPort);
+
+        return List.of(
+            Port.of(appPort, PortType.APPLICATION, Port.Security.SECURE),
+            Port.of(adminPort, PortType.ADMIN, Port.Security.SECURE)
+        );
     }
 
     private List<Port> assignSecureDynamicPortsToNewConnectors() {
@@ -181,23 +225,25 @@ public class PortAssigner {
 
     private HttpsConnectorFactory newHttpsConnectorFactory(int port) {
         var https = new HttpsConnectorFactory();
-
         https.setPort(port);
-        https.setKeyStorePath(tlsConfiguration.getKeyStorePath());
-        https.setKeyStorePassword(tlsConfiguration.getKeyStorePassword());
-        https.setKeyStoreType(tlsConfiguration.getKeyStoreType());
-        https.setKeyStoreProvider(tlsConfiguration.getKeyStoreProvider());
-        https.setTrustStorePath(tlsConfiguration.getTrustStorePath());
-        https.setTrustStorePassword(tlsConfiguration.getTrustStorePassword());
-        https.setTrustStoreType(tlsConfiguration.getTrustStoreType());
-        https.setTrustStoreProvider(tlsConfiguration.getTrustStoreProvider());
-        https.setJceProvider(tlsConfiguration.getProvider());
-        https.setCertAlias(tlsConfiguration.getCertAlias());
-        https.setSupportedProtocols(tlsConfiguration.getSupportedProtocols());
-        https.setSupportedCipherSuites(tlsConfiguration.getSupportedCiphers());
-        https.setDisableSniHostCheck(tlsConfiguration.isDisableSniHostCheck());
-
+        applyTlsConfiguration(https, tlsConfiguration);
         return https;
+    }
+
+    private static void applyTlsConfiguration(HttpsConnectorFactory https, TlsContextConfiguration tls) {
+        https.setKeyStorePath(tls.getKeyStorePath());
+        https.setKeyStorePassword(tls.getKeyStorePassword());
+        https.setKeyStoreType(tls.getKeyStoreType());
+        https.setKeyStoreProvider(tls.getKeyStoreProvider());
+        https.setTrustStorePath(tls.getTrustStorePath());
+        https.setTrustStorePassword(tls.getTrustStorePassword());
+        https.setTrustStoreType(tls.getTrustStoreType());
+        https.setTrustStoreProvider(tls.getTrustStoreProvider());
+        https.setJceProvider(tls.getProvider());
+        https.setCertAlias(tls.getCertAlias());
+        https.setSupportedProtocols(tls.getSupportedProtocols());
+        https.setSupportedCipherSuites(tls.getSupportedCiphers());
+        https.setDisableSniHostCheck(tls.isDisableSniHostCheck());
     }
 
     private List<Port> assignDynamicPortsToExistingConnectors() {

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/PortAssigner.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/PortAssigner.java
@@ -175,11 +175,16 @@ public class PortAssigner {
     }
 
     private List<Port> assignSecureDynamicPorts() {
-        if (first(serverFactory.getApplicationConnectors()) instanceof HttpsConnectorFactory appConnector
-                && first(serverFactory.getAdminConnectors()) instanceof HttpsConnectorFactory adminConnector) {
+        var firstAppConnector = first(serverFactory.getApplicationConnectors());
+        var firstAdminConnector = first(serverFactory.getAdminConnectors());
+        if (firstAppConnector instanceof HttpsConnectorFactory appConnector
+                && firstAdminConnector instanceof HttpsConnectorFactory adminConnector) {
             LOG.debug("Found existing HTTPS app/admin connectors; overlaying TLS config and assigning dynamic ports");
             return overlaySecureDynamicPortsOnExistingConnectors(appConnector, adminConnector);
         }
+        LOG.warn("App and admin connectors are not both HTTPS (app: {}, admin: {}); replacing all connectors with new HTTPS ones",
+                firstAppConnector.getClass().getSimpleName(),
+                firstAdminConnector.getClass().getSimpleName());
         return assignSecureDynamicPortsToNewConnectors();
     }
 

--- a/src/test/java/org/kiwiproject/dropwizard/util/startup/PortAssignerTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/startup/PortAssignerTest.java
@@ -20,6 +20,7 @@ import io.dropwizard.core.server.SimpleServerFactory;
 import io.dropwizard.jetty.ConnectorFactory;
 import io.dropwizard.jetty.HttpConnectorFactory;
 import io.dropwizard.jetty.HttpsConnectorFactory;
+import io.dropwizard.util.Duration;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -359,6 +360,157 @@ class PortAssignerTest {
                     () -> assertThat(httpsConnectorFactory.getSupportedCipherSuites()).isEqualTo(tlsConfig.getSupportedCiphers()),
                     () -> assertThat(httpsConnectorFactory.isDisableSniHostCheck()).isEqualTo(tlsConfig.isDisableSniHostCheck())
             );
+        }
+
+        @Test
+        void shouldOverlayTlsOnExistingHttpsAppConnector_WhenSecureSpecifiedAndHttpsConnectorsConfigured() {
+            var appConnector = new HttpsConnectorFactory();
+            appConnector.setIdleTimeout(Duration.seconds(42));
+            var adminConnector = new HttpsConnectorFactory();
+
+            var factory = new DefaultServerFactory();
+            factory.setApplicationConnectors(List.of(appConnector));
+            factory.setAdminConnectors(List.of(adminConnector));
+
+            var tlsConfig = TlsContextConfiguration.builder()
+                    .keyStorePath("/data/etc/pki/acme-ks.jks")
+                    .keyStorePassword("R3ally-hArd-passw0rD")
+                    .trustStorePath("/data/etc/pki/acme-ts.jks")
+                    .supportedProtocols(List.of("TLSv1.2", "TLSv1.3"))
+                    .disableSniHostCheck(true)
+                    .build();
+
+            var minPortNumber = 9_000;
+            var maxPortNumber = 9_100;
+            var allowedRange = new AllowablePortRange(minPortNumber, maxPortNumber);
+
+            var assigner = PortAssigner.builder()
+                    .portAssignment(DYNAMIC)
+                    .serverFactory(factory)
+                    .portSecurity(SECURE)
+                    .tlsConfiguration(tlsConfig)
+                    .allowablePortRange(allowedRange)
+                    .build();
+
+            var ports = assigner.assignDynamicPorts();
+
+            assertThat(first(ports).getNumber()).isBetween(minPortNumber, maxPortNumber);
+            assertThat(first(ports).getSecure()).isEqualTo(Port.Security.SECURE);
+            assertThat(second(ports).getNumber()).isBetween(minPortNumber, maxPortNumber);
+            assertThat(second(ports).getSecure()).isEqualTo(Port.Security.SECURE);
+
+            var resultAppConnector = assertIsExactType(first(factory.getApplicationConnectors()), HttpsConnectorFactory.class);
+            assertThat(resultAppConnector).isSameAs(appConnector);
+            assertThat(resultAppConnector.getPort()).isBetween(minPortNumber, maxPortNumber);
+            assertThat(resultAppConnector.getIdleTimeout()).isEqualTo(Duration.seconds(42));
+            assertSecureConnectorProperties(resultAppConnector, tlsConfig);
+        }
+
+        @Test
+        void shouldOverlayTlsOnExistingHttpsAdminConnector_WhenSecureSpecifiedAndHttpsConnectorsConfigured() {
+            var appConnector = new HttpsConnectorFactory();
+            var adminConnector = new HttpsConnectorFactory();
+            adminConnector.setIdleTimeout(Duration.seconds(42));
+
+            var factory = new DefaultServerFactory();
+            factory.setApplicationConnectors(List.of(appConnector));
+            factory.setAdminConnectors(List.of(adminConnector));
+
+            var tlsConfig = TlsContextConfiguration.builder()
+                    .keyStorePath("/data/etc/pki/acme-ks.jks")
+                    .keyStorePassword("R3ally-hArd-passw0rD")
+                    .trustStorePath("/data/etc/pki/acme-ts.jks")
+                    .supportedProtocols(List.of("TLSv1.2", "TLSv1.3"))
+                    .disableSniHostCheck(true)
+                    .build();
+
+            var minPortNumber = 9_000;
+            var maxPortNumber = 9_100;
+            var allowedRange = new AllowablePortRange(minPortNumber, maxPortNumber);
+
+            var assigner = PortAssigner.builder()
+                    .portAssignment(DYNAMIC)
+                    .serverFactory(factory)
+                    .portSecurity(SECURE)
+                    .tlsConfiguration(tlsConfig)
+                    .allowablePortRange(allowedRange)
+                    .build();
+
+            var ports = assigner.assignDynamicPorts();
+
+            assertThat(first(ports).getNumber()).isBetween(minPortNumber, maxPortNumber);
+            assertThat(first(ports).getSecure()).isEqualTo(Port.Security.SECURE);
+            assertThat(second(ports).getNumber()).isBetween(minPortNumber, maxPortNumber);
+            assertThat(second(ports).getSecure()).isEqualTo(Port.Security.SECURE);
+
+            var resultAdminConnector = assertIsExactType(first(factory.getAdminConnectors()), HttpsConnectorFactory.class);
+            assertThat(resultAdminConnector).isSameAs(adminConnector);
+            assertThat(resultAdminConnector.getPort()).isBetween(minPortNumber, maxPortNumber);
+            assertThat(resultAdminConnector.getIdleTimeout()).isEqualTo(Duration.seconds(42));
+            assertSecureConnectorProperties(resultAdminConnector, tlsConfig);
+        }
+
+        @Test
+        void shouldOverlayTlsOnExistingHttpsConnectors_AsZero_WhenPortRangeExcluded() {
+            var appConnector = new HttpsConnectorFactory();
+            var adminConnector = new HttpsConnectorFactory();
+
+            var factory = new DefaultServerFactory();
+            factory.setApplicationConnectors(List.of(appConnector));
+            factory.setAdminConnectors(List.of(adminConnector));
+
+            var tlsConfig = TlsContextConfiguration.builder()
+                    .keyStorePath("/data/etc/pki/acme-ks.jks")
+                    .keyStorePassword("R3ally-hArd-passw0rD")
+                    .trustStorePath("/data/etc/pki/acme-ts.jks")
+                    .build();
+
+            var assigner = PortAssigner.builder()
+                    .portAssignment(DYNAMIC)
+                    .serverFactory(factory)
+                    .portSecurity(SECURE)
+                    .tlsConfiguration(tlsConfig)
+                    .build();
+
+            var ports = assigner.assignDynamicPorts();
+
+            assertThat(first(ports).getNumber()).isZero();
+            assertThat(first(ports).getSecure()).isEqualTo(Port.Security.SECURE);
+            assertThat(second(ports).getNumber()).isZero();
+            assertThat(second(ports).getSecure()).isEqualTo(Port.Security.SECURE);
+
+            assertThat(first(factory.getApplicationConnectors())).isSameAs(appConnector);
+            assertThat(appConnector.getPort()).isZero();
+
+            assertThat(first(factory.getAdminConnectors())).isSameAs(adminConnector);
+            assertThat(adminConnector.getPort()).isZero();
+        }
+
+        @Test
+        void shouldReplaceConnectors_WhenSecureSpecified_AndOnlyAppConnectorIsHttps() {
+            var appConnector = new HttpsConnectorFactory();
+            var adminConnector = new HttpConnectorFactory();
+
+            var factory = new DefaultServerFactory();
+            factory.setApplicationConnectors(List.of(appConnector));
+            factory.setAdminConnectors(List.of(adminConnector));
+
+            var tlsConfig = TlsContextConfiguration.builder().build();
+
+            var assigner = PortAssigner.builder()
+                    .portAssignment(DYNAMIC)
+                    .serverFactory(factory)
+                    .portSecurity(SECURE)
+                    .tlsConfiguration(tlsConfig)
+                    .build();
+
+            assigner.assignDynamicPorts();
+
+            var resultAppConnector = assertIsExactType(first(factory.getApplicationConnectors()), HttpsConnectorFactory.class);
+            assertThat(resultAppConnector).isNotSameAs(appConnector);
+
+            var resultAdminConnector = assertIsExactType(first(factory.getAdminConnectors()), HttpsConnectorFactory.class);
+            assertThat(resultAdminConnector).isNotSameAs(adminConnector);
         }
 
         @Test


### PR DESCRIPTION
When PortSecurity is SECURE and both connectors are already HttpsConnectorFactory instances, assign dynamic ports and overlay TLS properties from TlsContextConfiguration onto the existing connectors, preserving all other connector properties from YAML such as idleTimeout and outputBufferSize. When existing connectors are not HTTPS, new HttpsConnectorFactory instances are created from scratch, preserving the existing behavior.

Extract applyTlsConfiguration as a shared static helper used by both the overlay and replace code paths.

Closes #667