### PR TITLE
Add AbstractCachingHealthCheck base class

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/health/AbstractCachingHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/AbstractCachingHealthCheck.java
@@ -99,6 +99,7 @@ public abstract class AbstractCachingHealthCheck extends HealthCheck {
      * @return the result of the health check
      * @throws Exception if the health check encounters an unexpected error
      */
+    @SuppressWarnings("java:S112")  // throws Exception mirrors HealthCheck#check() in the metrics library
     protected abstract Result doCheck() throws Exception;
 
     /**

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/AbstractCachingHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/AbstractCachingHealthCheck.java
@@ -25,6 +25,11 @@ import java.util.concurrent.atomic.AtomicReference;
  * without requiring callers to wrap your check in a {@link CachingHealthCheck} decorator.
  * This is especially useful for library authors who control the HealthCheck implementation
  * but want to give users the option to enable or disable caching at construction time.
+ * <p>
+ * <strong>Note:</strong> This class does not provide single-flight caching. If multiple
+ * threads call {@link #check()} concurrently after the cache has expired, more than one
+ * thread may invoke {@link #doCheck()}. The last write wins. If exactly-once recomputation
+ * is required, subclasses must handle that themselves.
  *
  * @see CachingHealthCheck
  */

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/AbstractCachingHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/AbstractCachingHealthCheck.java
@@ -1,0 +1,173 @@
+package org.kiwiproject.dropwizard.util.health;
+
+import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
+import static org.kiwiproject.logging.LazyLogParameterSupplier.lazy;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.google.common.annotations.VisibleForTesting;
+import lombok.extern.slf4j.Slf4j;
+import org.kiwiproject.base.DefaultEnvironment;
+import org.kiwiproject.base.KiwiEnvironment;
+import org.kiwiproject.metrics.health.HealthCheckResults;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * An abstract {@link HealthCheck} base class that provides optional result caching.
+ * <p>
+ * Subclasses implement {@link #doCheck()} to provide the actual health check logic.
+ * The {@link #check()} method (which is {@code final}) handles caching: it returns
+ * the cached result when within the expiration window, or delegates to {@link #doCheck()}
+ * when the cache has expired or caching is disabled.
+ * <p>
+ * Use this when you are implementing a HealthCheck and want to offer optional caching
+ * without requiring callers to wrap your check in a {@link CachingHealthCheck} decorator.
+ * This is especially useful for library authors who control the HealthCheck implementation
+ * but want to give users the option to enable or disable caching at construction time.
+ *
+ * @see CachingHealthCheck
+ */
+@Slf4j
+public abstract class AbstractCachingHealthCheck extends HealthCheck {
+
+    /**
+     * The default cache expiration duration (5 minutes).
+     */
+    public static final Duration DEFAULT_CACHE_EXPIRATION_DURATION = Duration.ofMinutes(5);
+
+    record TimestampedResult(long epochMillis, Result result) {
+    }
+
+    private final long cacheExpirationMillis;
+    private final boolean cachingEnabled;
+    private final KiwiEnvironment kiwiEnvironment;
+    private final AtomicReference<TimestampedResult> lastResultReference;
+
+    /**
+     * Create a new instance with caching enabled and the default cache expiration.
+     *
+     * @see #DEFAULT_CACHE_EXPIRATION_DURATION
+     */
+    protected AbstractCachingHealthCheck() {
+        this(DEFAULT_CACHE_EXPIRATION_DURATION, true);
+    }
+
+    /**
+     * Create a new instance with caching enabled and the given cache expiration.
+     *
+     * @param cacheExpiration the cache expiration period
+     */
+    protected AbstractCachingHealthCheck(Duration cacheExpiration) {
+        this(cacheExpiration, true);
+    }
+
+    /**
+     * Create a new instance with the default cache expiration.
+     *
+     * @param cachingEnabled whether caching is enabled
+     * @see #DEFAULT_CACHE_EXPIRATION_DURATION
+     */
+    protected AbstractCachingHealthCheck(boolean cachingEnabled) {
+        this(DEFAULT_CACHE_EXPIRATION_DURATION, cachingEnabled);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param cacheExpiration the cache expiration period
+     * @param cachingEnabled whether caching is enabled
+     */
+    protected AbstractCachingHealthCheck(Duration cacheExpiration, boolean cachingEnabled) {
+        this(cacheExpiration, cachingEnabled, new DefaultEnvironment());
+    }
+
+    @VisibleForTesting
+    AbstractCachingHealthCheck(Duration cacheExpiration, boolean cachingEnabled, KiwiEnvironment kiwiEnvironment) {
+        this.cacheExpirationMillis = requireNotNull(cacheExpiration).toMillis();
+        this.cachingEnabled = cachingEnabled;
+        this.kiwiEnvironment = kiwiEnvironment;
+        this.lastResultReference = new AtomicReference<>(new TimestampedResult(0, null));
+    }
+
+    /**
+     * Perform the actual health check logic.
+     * <p>
+     * Subclasses implement this method. It is called by {@link #check()} when
+     * the cache has expired or caching is disabled.
+     *
+     * @return the result of the health check
+     * @throws Exception if the health check encounters an unexpected error
+     */
+    protected abstract Result doCheck() throws Exception;
+
+    /**
+     * If caching is enabled and the cached result has not expired, returns the cached result.
+     * Otherwise, delegates to {@link #doCheck()}, caches the new result, and returns it.
+     * <p>
+     * If caching is disabled, always delegates to {@link #doCheck()}.
+     * <p>
+     * This method is {@code final}; subclasses must implement {@link #doCheck()} instead.
+     */
+    @Override
+    protected final Result check() {
+        if (!cachingEnabled) {
+            return executeDoCheck();
+        }
+
+        var nowEpochMillis = kiwiEnvironment.currentTimeMillis();
+        var lastResult = lastResultReference.get();
+        var millisSinceLastCheck = nowEpochMillis - lastResult.epochMillis();
+
+        if (millisSinceLastCheck < cacheExpirationMillis) {
+            logTimeSinceLastCheck(millisSinceLastCheck);
+            return lastResult.result();
+        }
+
+        LOG.debug("Time since last check ({} millis) is greater than cache expiration ({} millis). Do check.",
+                millisSinceLastCheck, cacheExpirationMillis);
+
+        return computeAndStoreResult().result();
+    }
+
+    private void logTimeSinceLastCheck(long millisSinceLastCheck) {
+        LOG.debug("Time since last check ({} millis) is less than cache expiration ({} millis)." +
+                        " Time until next check: {} millis. Returning last result.",
+                millisSinceLastCheck,
+                cacheExpirationMillis,
+                lazy(() -> cacheExpirationMillis - millisSinceLastCheck));
+    }
+
+    private TimestampedResult computeAndStoreResult() {
+        var result = executeDoCheck();
+        var timestampedResult = new TimestampedResult(kiwiEnvironment.currentTimeMillis(), result);
+        lastResultReference.set(timestampedResult);
+        return timestampedResult;
+    }
+
+    private Result executeDoCheck() {
+        try {
+            return doCheck();
+        } catch (Exception e) {
+            var className = getClass().getName();
+            LOG.warn("{}#doCheck threw an exception", className, e);
+            return HealthCheckResults.newUnhealthyResult(e,
+                    "%s#doCheck threw an exception. Exception: %s, Message: %s",
+                    className, e.getClass().getName(), e.getMessage());
+        }
+    }
+
+    /**
+     * @return whether caching is enabled for this health check
+     */
+    public boolean isCachingEnabled() {
+        return cachingEnabled;
+    }
+
+    /**
+     * @return the cache expiration period
+     */
+    public Duration cacheExpiration() {
+        return Duration.ofMillis(cacheExpirationMillis);
+    }
+}

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/AbstractCachingHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/AbstractCachingHealthCheck.java
@@ -31,11 +31,6 @@ import java.util.concurrent.atomic.AtomicReference;
 @Slf4j
 public abstract class AbstractCachingHealthCheck extends HealthCheck {
 
-    /**
-     * The default cache expiration duration (5 minutes).
-     */
-    public static final Duration DEFAULT_CACHE_EXPIRATION_DURATION = Duration.ofMinutes(5);
-
     record TimestampedResult(long epochMillis, Result result) {
     }
 

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/AbstractCachingHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/AbstractCachingHealthCheck.java
@@ -31,7 +31,7 @@ import java.util.concurrent.atomic.AtomicReference;
 @Slf4j
 public abstract class AbstractCachingHealthCheck extends HealthCheck {
 
-    record TimestampedResult(long epochMillis, Result result) {
+    private record TimestampedResult(long epochMillis, Result result) {
     }
 
     private final long cacheExpirationMillis;

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/AbstractCachingHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/AbstractCachingHealthCheck.java
@@ -45,34 +45,6 @@ public abstract class AbstractCachingHealthCheck extends HealthCheck {
     private final AtomicReference<TimestampedResult> lastResultReference;
 
     /**
-     * Create a new instance with caching enabled and the default cache expiration.
-     *
-     * @see #DEFAULT_CACHE_EXPIRATION_DURATION
-     */
-    protected AbstractCachingHealthCheck() {
-        this(DEFAULT_CACHE_EXPIRATION_DURATION, true);
-    }
-
-    /**
-     * Create a new instance with caching enabled and the given cache expiration.
-     *
-     * @param cacheExpiration the cache expiration period
-     */
-    protected AbstractCachingHealthCheck(Duration cacheExpiration) {
-        this(cacheExpiration, true);
-    }
-
-    /**
-     * Create a new instance with the default cache expiration.
-     *
-     * @param cachingEnabled whether caching is enabled
-     * @see #DEFAULT_CACHE_EXPIRATION_DURATION
-     */
-    protected AbstractCachingHealthCheck(boolean cachingEnabled) {
-        this(DEFAULT_CACHE_EXPIRATION_DURATION, cachingEnabled);
-    }
-
-    /**
      * Create a new instance.
      *
      * @param cacheExpiration the cache expiration period

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/CachingHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/CachingHealthCheck.java
@@ -25,6 +25,12 @@ import java.util.concurrent.atomic.AtomicReference;
  * Use this if a HealthCheck is expensive to compute, and you want to minimize
  * the execution cost. For example, a HealthCheck that makes network calls might
  * be a good candidate for caching if health checks are executed frequently.
+ * <p>
+ * <strong>Note:</strong> This class does not provide single-flight caching. If multiple
+ * threads call {@link #check()} concurrently after the cache has expired, more than one
+ * thread may execute the wrapped HealthCheck. The last write wins. If exactly-once
+ * recomputation is required, wrap the HealthCheck with appropriate synchronization before
+ * passing it to this class.
  *
  * @see AbstractCachingHealthCheck
  */

--- a/src/main/java/org/kiwiproject/dropwizard/util/health/CachingHealthCheck.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/health/CachingHealthCheck.java
@@ -25,6 +25,8 @@ import java.util.concurrent.atomic.AtomicReference;
  * Use this if a HealthCheck is expensive to compute, and you want to minimize
  * the execution cost. For example, a HealthCheck that makes network calls might
  * be a good candidate for caching if health checks are executed frequently.
+ *
+ * @see AbstractCachingHealthCheck
  */
 @Slf4j
 public class CachingHealthCheck extends HealthCheck {

--- a/src/test/java/org/kiwiproject/dropwizard/util/health/AbstractCachingHealthCheckTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/health/AbstractCachingHealthCheckTest.java
@@ -35,27 +35,11 @@ class AbstractCachingHealthCheckTest {
     class Construction {
 
         @Test
-        void shouldCreateWithDefaultCacheExpirationAndCachingEnabled() {
-            var healthCheck = new HappyHealthCheck();
-            assertThat(healthCheck.cacheExpiration())
-                    .isEqualTo(AbstractCachingHealthCheck.DEFAULT_CACHE_EXPIRATION_DURATION);
-            assertThat(healthCheck.isCachingEnabled()).isTrue();
-        }
-
-        @Test
-        void shouldCreateWithCustomCacheExpiration() {
+        void shouldCreateWithCustomExpirationAndCachingEnabled() {
             var twoMinutes = Duration.ofMinutes(2);
-            var healthCheck = new HappyHealthCheck(twoMinutes);
+            var healthCheck = new HappyHealthCheck(twoMinutes, true);
             assertThat(healthCheck.cacheExpiration()).isEqualTo(twoMinutes);
             assertThat(healthCheck.isCachingEnabled()).isTrue();
-        }
-
-        @Test
-        void shouldCreateWithCachingDisabled() {
-            var healthCheck = new HappyHealthCheck(false);
-            assertThat(healthCheck.cacheExpiration())
-                    .isEqualTo(AbstractCachingHealthCheck.DEFAULT_CACHE_EXPIRATION_DURATION);
-            assertThat(healthCheck.isCachingEnabled()).isFalse();
         }
 
         @Test
@@ -176,7 +160,7 @@ class AbstractCachingHealthCheckTest {
 
         @Test
         void shouldAlwaysInvokeDoCheck() {
-            var healthCheck = new HappyHealthCheck(false);
+            var healthCheck = new HappyHealthCheck(AbstractCachingHealthCheck.DEFAULT_CACHE_EXPIRATION_DURATION, false);
 
             assertThatHealthCheck(healthCheck).isHealthy().hasMessage("Everything is awesome! Count: 1");
             assertThatHealthCheck(healthCheck).isHealthy().hasMessage("Everything is awesome! Count: 2");
@@ -185,7 +169,7 @@ class AbstractCachingHealthCheckTest {
 
         @Test
         void shouldCatchExceptionsFromDoCheck_AndReturnUnhealthyResult() {
-            var healthCheck = new BadHealthCheck(false);
+            var healthCheck = new BadHealthCheck(AbstractCachingHealthCheck.DEFAULT_CACHE_EXPIRATION_DURATION, false);
 
             var expectedMessage = f("{}#doCheck threw an exception. Exception: java.lang.RuntimeException, Message: Oops. Count: 1",
                     BadHealthCheck.class.getName());
@@ -200,18 +184,6 @@ class AbstractCachingHealthCheckTest {
 
     static class HappyHealthCheck extends AbstractCachingHealthCheck {
         private final AtomicInteger count = new AtomicInteger();
-
-        HappyHealthCheck() {
-            super();
-        }
-
-        HappyHealthCheck(Duration cacheExpiration) {
-            super(cacheExpiration);
-        }
-
-        HappyHealthCheck(boolean cachingEnabled) {
-            super(cachingEnabled);
-        }
 
         HappyHealthCheck(Duration cacheExpiration, boolean cachingEnabled) {
             super(cacheExpiration, cachingEnabled);
@@ -230,8 +202,8 @@ class AbstractCachingHealthCheckTest {
     static class BadHealthCheck extends AbstractCachingHealthCheck {
         private final AtomicInteger count = new AtomicInteger();
 
-        BadHealthCheck(boolean cachingEnabled) {
-            super(cachingEnabled);
+        BadHealthCheck(Duration cacheExpiration, boolean cachingEnabled) {
+            super(cacheExpiration, cachingEnabled);
         }
 
         BadHealthCheck(Duration cacheExpiration, boolean cachingEnabled, KiwiEnvironment kiwiEnvironment) {

--- a/src/test/java/org/kiwiproject/dropwizard/util/health/AbstractCachingHealthCheckTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/health/AbstractCachingHealthCheckTest.java
@@ -160,7 +160,7 @@ class AbstractCachingHealthCheckTest {
 
         @Test
         void shouldAlwaysInvokeDoCheck() {
-            var healthCheck = new HappyHealthCheck(AbstractCachingHealthCheck.DEFAULT_CACHE_EXPIRATION_DURATION, false);
+            var healthCheck = new HappyHealthCheck(Duration.ofMinutes(5), false);
 
             assertThatHealthCheck(healthCheck).isHealthy().hasMessage("Everything is awesome! Count: 1");
             assertThatHealthCheck(healthCheck).isHealthy().hasMessage("Everything is awesome! Count: 2");
@@ -169,7 +169,7 @@ class AbstractCachingHealthCheckTest {
 
         @Test
         void shouldCatchExceptionsFromDoCheck_AndReturnUnhealthyResult() {
-            var healthCheck = new BadHealthCheck(AbstractCachingHealthCheck.DEFAULT_CACHE_EXPIRATION_DURATION, false);
+            var healthCheck = new BadHealthCheck(Duration.ofMinutes(5), false);
 
             var expectedMessage = f("{}#doCheck threw an exception. Exception: java.lang.RuntimeException, Message: Oops. Count: 1",
                     BadHealthCheck.class.getName());

--- a/src/test/java/org/kiwiproject/dropwizard/util/health/AbstractCachingHealthCheckTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/health/AbstractCachingHealthCheckTest.java
@@ -1,0 +1,246 @@
+package org.kiwiproject.dropwizard.util.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kiwiproject.base.KiwiStrings.f;
+import static org.kiwiproject.test.assertj.dropwizard.metrics.HealthCheckResultAssertions.assertThatHealthCheck;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.health.HealthCheck;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.base.KiwiEnvironment;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@DisplayName("AbstractCachingHealthCheck")
+class AbstractCachingHealthCheckTest {
+
+    private KiwiEnvironment kiwiEnvironment;
+
+    @BeforeEach
+    void setUp() {
+        kiwiEnvironment = mock(KiwiEnvironment.class);
+    }
+
+    @Nested
+    class Construction {
+
+        @Test
+        void shouldCreateWithDefaultCacheExpirationAndCachingEnabled() {
+            var healthCheck = new HappyHealthCheck();
+            assertThat(healthCheck.cacheExpiration())
+                    .isEqualTo(AbstractCachingHealthCheck.DEFAULT_CACHE_EXPIRATION_DURATION);
+            assertThat(healthCheck.isCachingEnabled()).isTrue();
+        }
+
+        @Test
+        void shouldCreateWithCustomCacheExpiration() {
+            var twoMinutes = Duration.ofMinutes(2);
+            var healthCheck = new HappyHealthCheck(twoMinutes);
+            assertThat(healthCheck.cacheExpiration()).isEqualTo(twoMinutes);
+            assertThat(healthCheck.isCachingEnabled()).isTrue();
+        }
+
+        @Test
+        void shouldCreateWithCachingDisabled() {
+            var healthCheck = new HappyHealthCheck(false);
+            assertThat(healthCheck.cacheExpiration())
+                    .isEqualTo(AbstractCachingHealthCheck.DEFAULT_CACHE_EXPIRATION_DURATION);
+            assertThat(healthCheck.isCachingEnabled()).isFalse();
+        }
+
+        @Test
+        void shouldCreateWithCustomExpirationAndCachingDisabled() {
+            var tenSeconds = Duration.ofSeconds(10);
+            var healthCheck = new HappyHealthCheck(tenSeconds, false);
+            assertThat(healthCheck.cacheExpiration()).isEqualTo(tenSeconds);
+            assertThat(healthCheck.isCachingEnabled()).isFalse();
+        }
+    }
+
+    @Nested
+    class WithCachingEnabled {
+
+        @Test
+        void shouldReturnCachedResult_WhenCacheHasNotExpired() {
+            var expiration = Duration.ofSeconds(30);
+            var healthCheck = new HappyHealthCheck(expiration, true, kiwiEnvironment);
+
+            var firstCheckTime = Instant.now();
+            var secondCheckTime = firstCheckTime.plusSeconds(12);
+            var thirdCheckTime = firstCheckTime.plusSeconds(29);
+
+            when(kiwiEnvironment.currentTimeMillis())
+                    .thenReturn(firstCheckTime.toEpochMilli())
+                    .thenReturn(firstCheckTime.toEpochMilli() + smallDelay())  // during TimestampedResult creation
+                    .thenReturn(secondCheckTime.toEpochMilli())
+                    .thenReturn(thirdCheckTime.toEpochMilli());
+
+            var expectedMessage = "Everything is awesome! Count: 1";
+
+            // First check should invoke doCheck
+            assertThatHealthCheck(healthCheck)
+                    .isHealthy()
+                    .hasMessage(expectedMessage);
+
+            // Second and third checks should return the same (cached) result
+            assertThatHealthCheck(healthCheck)
+                    .isHealthy()
+                    .hasMessage(expectedMessage);
+
+            assertThatHealthCheck(healthCheck)
+                    .isHealthy()
+                    .hasMessage(expectedMessage);
+
+            verify(kiwiEnvironment, times(4)).currentTimeMillis();
+            verifyNoMoreInteractions(kiwiEnvironment);
+        }
+
+        @Test
+        void shouldExecuteDoCheck_WhenCacheHasExpired() {
+            var expiration = Duration.ofSeconds(30);
+            var healthCheck = new HappyHealthCheck(expiration, true, kiwiEnvironment);
+
+            var firstCheckTime = Instant.now();
+            var secondCheckTime = firstCheckTime.plusSeconds(15);
+            var thirdCheckTime = firstCheckTime.plusSeconds(31);
+
+            when(kiwiEnvironment.currentTimeMillis())
+                    .thenReturn(firstCheckTime.toEpochMilli())
+                    .thenReturn(firstCheckTime.toEpochMilli() + smallDelay())  // during TimestampedResult creation
+                    .thenReturn(secondCheckTime.toEpochMilli())
+                    .thenReturn(thirdCheckTime.toEpochMilli())
+                    .thenReturn(thirdCheckTime.toEpochMilli() + smallDelay());  // during TimestampedResult creation
+
+            // First check invokes doCheck
+            assertThatHealthCheck(healthCheck)
+                    .isHealthy()
+                    .hasMessage("Everything is awesome! Count: 1");
+
+            // Second check returns cached result
+            assertThatHealthCheck(healthCheck)
+                    .isHealthy()
+                    .hasMessage("Everything is awesome! Count: 1");
+
+            // Third check invokes doCheck again after cache expiration
+            assertThatHealthCheck(healthCheck)
+                    .isHealthy()
+                    .hasMessage("Everything is awesome! Count: 2");
+
+            verify(kiwiEnvironment, times(5)).currentTimeMillis();
+            verifyNoMoreInteractions(kiwiEnvironment);
+        }
+
+        @Test
+        void shouldCatchExceptionsFromDoCheck_AndReturnUnhealthyResult() {
+            var expiration = Duration.ofMinutes(10);
+            var healthCheck = new BadHealthCheck(expiration, true, kiwiEnvironment);
+
+            var firstCheckTime = Instant.now();
+            var secondCheckTime = firstCheckTime.plusSeconds(5);
+
+            when(kiwiEnvironment.currentTimeMillis())
+                    .thenReturn(firstCheckTime.toEpochMilli())
+                    .thenReturn(firstCheckTime.toEpochMilli() + smallDelay())  // during TimestampedResult creation
+                    .thenReturn(secondCheckTime.toEpochMilli());
+
+            var expectedMessage = f("{}#doCheck threw an exception. Exception: java.lang.RuntimeException, Message: Oops. Count: 1",
+                    BadHealthCheck.class.getName());
+
+            // First check invokes doCheck and catches the exception
+            assertThatHealthCheck(healthCheck)
+                    .isUnhealthy()
+                    .hasMessage(expectedMessage);
+
+            // Second check returns the cached unhealthy result
+            assertThatHealthCheck(healthCheck)
+                    .isUnhealthy()
+                    .hasMessage(expectedMessage);
+
+            verify(kiwiEnvironment, times(3)).currentTimeMillis();
+            verifyNoMoreInteractions(kiwiEnvironment);
+        }
+    }
+
+    @Nested
+    class WithCachingDisabled {
+
+        @Test
+        void shouldAlwaysInvokeDoCheck() {
+            var healthCheck = new HappyHealthCheck(false);
+
+            assertThatHealthCheck(healthCheck).isHealthy().hasMessage("Everything is awesome! Count: 1");
+            assertThatHealthCheck(healthCheck).isHealthy().hasMessage("Everything is awesome! Count: 2");
+            assertThatHealthCheck(healthCheck).isHealthy().hasMessage("Everything is awesome! Count: 3");
+        }
+
+        @Test
+        void shouldCatchExceptionsFromDoCheck_AndReturnUnhealthyResult() {
+            var healthCheck = new BadHealthCheck(false);
+
+            var expectedMessage = f("{}#doCheck threw an exception. Exception: java.lang.RuntimeException, Message: Oops. Count: 1",
+                    BadHealthCheck.class.getName());
+
+            assertThatHealthCheck(healthCheck).isUnhealthy().hasMessage(expectedMessage);
+        }
+    }
+
+    private static long smallDelay() {
+        return ThreadLocalRandom.current().nextLong(5, 10);
+    }
+
+    static class HappyHealthCheck extends AbstractCachingHealthCheck {
+        private final AtomicInteger count = new AtomicInteger();
+
+        HappyHealthCheck() {
+            super();
+        }
+
+        HappyHealthCheck(Duration cacheExpiration) {
+            super(cacheExpiration);
+        }
+
+        HappyHealthCheck(boolean cachingEnabled) {
+            super(cachingEnabled);
+        }
+
+        HappyHealthCheck(Duration cacheExpiration, boolean cachingEnabled) {
+            super(cacheExpiration, cachingEnabled);
+        }
+
+        HappyHealthCheck(Duration cacheExpiration, boolean cachingEnabled, KiwiEnvironment kiwiEnvironment) {
+            super(cacheExpiration, cachingEnabled, kiwiEnvironment);
+        }
+
+        @Override
+        protected HealthCheck.Result doCheck() {
+            return Result.healthy("Everything is awesome! Count: " + count.incrementAndGet());
+        }
+    }
+
+    static class BadHealthCheck extends AbstractCachingHealthCheck {
+        private final AtomicInteger count = new AtomicInteger();
+
+        BadHealthCheck(boolean cachingEnabled) {
+            super(cachingEnabled);
+        }
+
+        BadHealthCheck(Duration cacheExpiration, boolean cachingEnabled, KiwiEnvironment kiwiEnvironment) {
+            super(cacheExpiration, cachingEnabled, kiwiEnvironment);
+        }
+
+        @Override
+        protected HealthCheck.Result doCheck() {
+            throw new RuntimeException("Oops. Count: " + count.incrementAndGet());
+        }
+    }
+}


### PR DESCRIPTION
- Adds `AbstractCachingHealthCheck`, an abstract base class that uses the template method pattern to provide optional result caching
- Subclasses implement `doCheck()`; the `final check()` method handles caching - returning the cached result within the expiration window, or delegating to `doCheck()` when expired
- A single constructor takes `(Duration cacheExpiration, boolean cachingEnabled)` - both values are intended to come from configuration
- Complements the existing `CachingHealthCheck` decorator, which requires wrapping an existing `HealthCheck` instance — this class is for authors building a health check who want to offer caching as a built-in option
- Adds a Javadoc note to both classes clarifying that neither provides single-flight caching - concurrent threads may each invoke the check after expiration, with the last write winning

Closes #669