### PR TITLE
Deprecate ExecutionStrategy, ExecutionStrategies, and SystemExecutioner

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategies.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategies.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
         replacedBy = "org.kiwiproject.base.system.ExecutionStrategies",
         reference = "#673"
 )
+@SuppressWarnings("removal")
 @UtilityClass
 public class ExecutionStrategies {
 

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategies.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategies.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
         replacedBy = "org.kiwiproject.base.system.ExecutionStrategies",
         reference = "#673"
 )
-@SuppressWarnings("removal")
+@SuppressWarnings({"removal", "java:S1133"})
 @UtilityClass
 public class ExecutionStrategies {
 

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategies.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategies.java
@@ -11,8 +11,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Factory for {@link ExecutionStrategy} instances.
  *
  * @deprecated This class is moving to kiwi as {@code org.kiwiproject.base.system.ExecutionStrategies}
- * in kiwi 5.4.0 and will be removed from this library in 6.0.0. No action is required yet — this
- * is an advance warning. Note that the kiwi implementations reflect the API changes in
+ * in kiwi 5.4.0 and will be removed from this library in 6.0.0. No action is required yet;
+ * migration will be possible once kiwi 5.4.0 is available. Note that the kiwi implementations
+ * reflect the API changes in
  * {@code org.kiwiproject.base.system.ExecutionStrategy}.
  */
 @Deprecated(since = "5.3.0", forRemoval = true)

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategies.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategies.java
@@ -10,10 +10,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * Factory for {@link ExecutionStrategy} instances.
  *
- * @deprecated This class is moving to kiwi as {@link org.kiwiproject.base.system.ExecutionStrategies}
+ * @deprecated This class is moving to kiwi as {@code org.kiwiproject.base.system.ExecutionStrategies}
  * in kiwi 5.4.0 and will be removed from this library in 6.0.0. No action is required yet — this
  * is an advance warning. Note that the kiwi implementations reflect the API changes in
- * {@link org.kiwiproject.base.system.ExecutionStrategy}.
+ * {@code org.kiwiproject.base.system.ExecutionStrategy}.
  */
 @Deprecated(since = "5.3.0", forRemoval = true)
 @KiwiDeprecated(

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategies.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategies.java
@@ -10,9 +10,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * Factory for {@link ExecutionStrategy} instances.
  *
- * @deprecated Use {@link org.kiwiproject.base.system.ExecutionStrategies} in kiwi (5.4.0+) instead.
- * Note that the kiwi implementations reflect the API changes in
- * {@link org.kiwiproject.base.system.ExecutionStrategy}. Will be removed in 6.0.0.
+ * @deprecated This class is moving to kiwi as {@link org.kiwiproject.base.system.ExecutionStrategies}
+ * in kiwi 5.4.0 and will be removed from this library in 6.0.0. No action is required yet — this
+ * is an advance warning. Note that the kiwi implementations reflect the API changes in
+ * {@link org.kiwiproject.base.system.ExecutionStrategy}.
  */
 @Deprecated(since = "5.3.0", forRemoval = true)
 @KiwiDeprecated(

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategies.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategies.java
@@ -3,12 +3,24 @@ package org.kiwiproject.dropwizard.util.startup;
 import lombok.Getter;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
+import org.kiwiproject.base.KiwiDeprecated;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Factory for {@link ExecutionStrategy} instances.
+ *
+ * @deprecated Use {@link org.kiwiproject.base.system.ExecutionStrategies} in kiwi (5.4.0+) instead.
+ * Note that the kiwi implementations reflect the API changes in
+ * {@link org.kiwiproject.base.system.ExecutionStrategy}. Will be removed in 6.0.0.
  */
+@Deprecated(since = "5.3.0", forRemoval = true)
+@KiwiDeprecated(
+        since = "5.3.0",
+        removeAt = "6.0.0",
+        replacedBy = "org.kiwiproject.base.system.ExecutionStrategies",
+        reference = "#673"
+)
 @UtilityClass
 public class ExecutionStrategies {
 

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategies.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategies.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
         replacedBy = "org.kiwiproject.base.system.ExecutionStrategies",
         reference = "#673"
 )
-@SuppressWarnings({"removal", "java:S1133"})
+@SuppressWarnings({ "removal", "java:S1133", "DeprecatedIsStillUsed" })
 @UtilityClass
 public class ExecutionStrategies {
 

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategy.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategy.java
@@ -5,9 +5,10 @@ import org.kiwiproject.base.KiwiDeprecated;
 /**
  * Defines a strategy used in {@link SystemExecutioner} to terminate the JVM.
  *
- * @deprecated Use {@link org.kiwiproject.base.system.ExecutionStrategy} in kiwi (5.4.0+) instead.
- * Note that the kiwi version declares only {@code exit(int exitCode)}, requiring an explicit
- * exit code rather than relying on a default. Will be removed in 6.0.0.
+ * @deprecated This class is moving to kiwi as {@link org.kiwiproject.base.system.ExecutionStrategy}
+ * in kiwi 5.4.0 and will be removed from this library in 6.0.0. No action is required yet — this
+ * is an advance warning. Note that the kiwi version declares only {@code exit(int exitCode)},
+ * requiring an explicit exit code rather than relying on a default.
  */
 @Deprecated(since = "5.3.0", forRemoval = true)
 @KiwiDeprecated(

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategy.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategy.java
@@ -1,8 +1,21 @@
 package org.kiwiproject.dropwizard.util.startup;
 
+import org.kiwiproject.base.KiwiDeprecated;
+
 /**
  * Defines a strategy used in {@link SystemExecutioner} to terminate the JVM.
+ *
+ * @deprecated Use {@link org.kiwiproject.base.system.ExecutionStrategy} in kiwi (5.4.0+) instead.
+ * Note that the kiwi version declares only {@code exit(int exitCode)}, requiring an explicit
+ * exit code rather than relying on a default. Will be removed in 6.0.0.
  */
+@Deprecated(since = "5.3.0", forRemoval = true)
+@KiwiDeprecated(
+        since = "5.3.0",
+        removeAt = "6.0.0",
+        replacedBy = "org.kiwiproject.base.system.ExecutionStrategy",
+        reference = "#673"
+)
 public interface ExecutionStrategy {
 
     /**

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategy.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategy.java
@@ -17,6 +17,7 @@ import org.kiwiproject.base.KiwiDeprecated;
         replacedBy = "org.kiwiproject.base.system.ExecutionStrategy",
         reference = "#673"
 )
+@SuppressWarnings("java:S1133")
 public interface ExecutionStrategy {
 
     /**

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategy.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategy.java
@@ -6,8 +6,9 @@ import org.kiwiproject.base.KiwiDeprecated;
  * Defines a strategy used in {@link SystemExecutioner} to terminate the JVM.
  *
  * @deprecated This class is moving to kiwi as {@code org.kiwiproject.base.system.ExecutionStrategy}
- * in kiwi 5.4.0 and will be removed from this library in 6.0.0. No action is required yet — this
- * is an advance warning. Note that the kiwi version declares only {@code exit(int exitCode)},
+ * in kiwi 5.4.0 and will be removed from this library in 6.0.0. No action is required yet;
+ * migration will be possible once kiwi 5.4.0 is available. Note that the kiwi version declares
+ * only {@code exit(int exitCode)},
  * requiring an explicit exit code rather than relying on a default.
  */
 @Deprecated(since = "5.3.0", forRemoval = true)

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategy.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategy.java
@@ -5,7 +5,7 @@ import org.kiwiproject.base.KiwiDeprecated;
 /**
  * Defines a strategy used in {@link SystemExecutioner} to terminate the JVM.
  *
- * @deprecated This class is moving to kiwi as {@link org.kiwiproject.base.system.ExecutionStrategy}
+ * @deprecated This class is moving to kiwi as {@code org.kiwiproject.base.system.ExecutionStrategy}
  * in kiwi 5.4.0 and will be removed from this library in 6.0.0. No action is required yet — this
  * is an advance warning. Note that the kiwi version declares only {@code exit(int exitCode)},
  * requiring an explicit exit code rather than relying on a default.

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategy.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategy.java
@@ -17,7 +17,7 @@ import org.kiwiproject.base.KiwiDeprecated;
         replacedBy = "org.kiwiproject.base.system.ExecutionStrategy",
         reference = "#673"
 )
-@SuppressWarnings("java:S1133")
+@SuppressWarnings({ "java:S1133", "removal", "DeprecatedIsStillUsed" })
 public interface ExecutionStrategy {
 
     /**

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/SystemExecutioner.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/SystemExecutioner.java
@@ -5,6 +5,7 @@ import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.kiwiproject.base.DefaultEnvironment;
+import org.kiwiproject.base.KiwiDeprecated;
 
 import java.util.concurrent.TimeUnit;
 
@@ -20,7 +21,19 @@ import java.util.concurrent.TimeUnit;
  * {@link System#exit(int)} to terminate the JVM. You can supply your own {@link ExecutionStrategy} as well, for
  * example {@link ExecutionStrategies.NoOpExecutionStrategy} is useful in unit tests (so it doesn't actually terminate
  * the JVM).
+ *
+ * @deprecated Use {@link org.kiwiproject.base.system.SystemExecutioner} in kiwi (5.4.0+) instead.
+ * Note that the kiwi version has a different API: exit methods require an explicit exit code, and the
+ * timed exit uses {@link java.time.Duration} instead of {@link java.util.concurrent.TimeUnit}.
+ * Will be removed in 6.0.0.
  */
+@Deprecated(since = "5.3.0", forRemoval = true)
+@KiwiDeprecated(
+        since = "5.3.0",
+        removeAt = "6.0.0",
+        replacedBy = "org.kiwiproject.base.system.SystemExecutioner",
+        reference = "#673"
+)
 @Slf4j
 public class SystemExecutioner {
 

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/SystemExecutioner.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/SystemExecutioner.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
  * example {@link ExecutionStrategies.NoOpExecutionStrategy} is useful in unit tests (so it doesn't actually terminate
  * the JVM).
  *
- * @deprecated This class is moving to kiwi as {@link org.kiwiproject.base.system.SystemExecutioner}
+ * @deprecated This class is moving to kiwi as {@code org.kiwiproject.base.system.SystemExecutioner}
  * in kiwi 5.4.0 and will be removed from this library in 6.0.0. No action is required yet — this
  * is an advance warning. Note that the kiwi version has a different API: exit methods require an
  * explicit exit code, and the timed exit uses {@link java.time.Duration} instead of

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/SystemExecutioner.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/SystemExecutioner.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
         replacedBy = "org.kiwiproject.base.system.SystemExecutioner",
         reference = "#673"
 )
+@SuppressWarnings("removal")
 @Slf4j
 public class SystemExecutioner {
 

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/SystemExecutioner.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/SystemExecutioner.java
@@ -22,10 +22,11 @@ import java.util.concurrent.TimeUnit;
  * example {@link ExecutionStrategies.NoOpExecutionStrategy} is useful in unit tests (so it doesn't actually terminate
  * the JVM).
  *
- * @deprecated Use {@link org.kiwiproject.base.system.SystemExecutioner} in kiwi (5.4.0+) instead.
- * Note that the kiwi version has a different API: exit methods require an explicit exit code, and the
- * timed exit uses {@link java.time.Duration} instead of {@link java.util.concurrent.TimeUnit}.
- * Will be removed in 6.0.0.
+ * @deprecated This class is moving to kiwi as {@link org.kiwiproject.base.system.SystemExecutioner}
+ * in kiwi 5.4.0 and will be removed from this library in 6.0.0. No action is required yet — this
+ * is an advance warning. Note that the kiwi version has a different API: exit methods require an
+ * explicit exit code, and the timed exit uses {@link java.time.Duration} instead of
+ * {@link java.util.concurrent.TimeUnit}.
  */
 @Deprecated(since = "5.3.0", forRemoval = true)
 @KiwiDeprecated(

--- a/src/main/java/org/kiwiproject/dropwizard/util/startup/SystemExecutioner.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/startup/SystemExecutioner.java
@@ -23,8 +23,9 @@ import java.util.concurrent.TimeUnit;
  * the JVM).
  *
  * @deprecated This class is moving to kiwi as {@code org.kiwiproject.base.system.SystemExecutioner}
- * in kiwi 5.4.0 and will be removed from this library in 6.0.0. No action is required yet — this
- * is an advance warning. Note that the kiwi version has a different API: exit methods require an
+ * in kiwi 5.4.0 and will be removed from this library in 6.0.0. No action is required yet;
+ * migration will be possible once kiwi 5.4.0 is available. Note that the kiwi version has a
+ * different API: exit methods require an
  * explicit exit code, and the timed exit uses {@link java.time.Duration} instead of
  * {@link java.util.concurrent.TimeUnit}.
  */

--- a/src/test/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategiesTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/startup/ExecutionStrategiesTest.java
@@ -19,6 +19,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+@SuppressWarnings("removal")
 @DisplayName("ExecutionStrategies")
 @Slf4j
 class ExecutionStrategiesTest {

--- a/src/test/java/org/kiwiproject/dropwizard/util/startup/SystemExecutionerTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/startup/SystemExecutionerTest.java
@@ -15,6 +15,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+@SuppressWarnings("removal")
 @DisplayName("SystemExecutioner")
 @Slf4j
 class SystemExecutionerTest {


### PR DESCRIPTION
Deprecates ExecutionStrategy, ExecutionStrategies, and SystemExecutioner
in favor of the equivalents being added to kiwi in org.kiwiproject.base.system
(available in kiwi 5.4.0). All three classes are annotated with both
the Deprecated(since = "5.3.0", forRemoval = true) and KiwiDeprecated
annotations with since, removeAt, replacedBy, and reference attributes.

The kiwi API differs in a few notable ways: ExecutionStrategy declares
only exit(int exitCode) with no no-arg version, SystemExitExecutionStrategy
is stateless, and SystemExecutioner uses Duration for timed exits instead
of TimeUnit.

Closes #673